### PR TITLE
Fix duplicate save action in notes app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Notes_App
 A personal notes app that works in the browser.
+
+## Features
+
+- Toggle between light and dark mode. Your choice is remembered between visits.
+- Save your notes as a Markdown file. Specify a filename or use the default `untitled.md`.

--- a/script.js
+++ b/script.js
@@ -19,22 +19,9 @@ toggleBtn.addEventListener('click', toggleTheme);
 const savedTheme = localStorage.getItem('theme') || 'light';
 applyTheme(savedTheme);
 
-// Save markdown file
-saveBtn.addEventListener('click', () => {
-  const text = textarea.value;
-  const blob = new Blob([text], { type: 'text/markdown' });
-  const url = URL.createObjectURL(blob);
-
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'note.md';
-  a.click();
-
-  URL.revokeObjectURL(url);
-});
-
 const filenameInput = document.getElementById('filename-input');
 
+// Save the contents of the textarea as a markdown file
 saveBtn.addEventListener('click', () => {
   const text = textarea.value;
   const filename = filenameInput.value.trim() || 'untitled';


### PR DESCRIPTION
## Summary
- remove redundant save handler that triggered double downloads
- document features in the README

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b04a96748832d923ef09a4bd33d53