### PR TITLE
Add date default filename and markdown preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A personal notes app that works in the browser.
 ## Features
 
 - Toggle between light and dark mode. Your choice is remembered between visits.
-- Save your notes as a Markdown file. Specify a filename or use the default `untitled.md`.
+- Save your notes as a Markdown file. Specify a filename or use the default name based on today's date.
 - Save notes to your browser using localStorage and load them later.
 - Search through saved notes and download them all as a zip archive.
+- Toggle between editing and previewing your markdown.

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <title>Notes App</title>
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
   <button id="toggle-theme" class="sun" aria-label="Toggle Dark Mode"></button>
@@ -12,6 +13,8 @@
   <h1>Notes App</h1>
   <input type="text" id="filename-input" placeholder="Enter filename (without .md)">
   <textarea id="editor" placeholder="Start typing here..."></textarea>
+  <div id="preview" style="display:none;"></div>
+  <button id="toggle-view">Preview Markdown</button>
 
   <div class="storage-controls">
     <button id="save-storage">Save</button>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,8 @@
 const toggleBtn = document.getElementById('toggle-theme');
 const textarea = document.getElementById('editor');
+const previewDiv = document.getElementById('preview');
+const toggleViewBtn = document.getElementById('toggle-view');
+let isPreview = false;
 
 function applyTheme(theme) {
   document.body.classList.toggle('dark-mode', theme === 'dark');
@@ -25,6 +28,37 @@ const loadStorageBtn = document.getElementById('load-storage');
 const downloadAllBtn = document.getElementById('download-all');
 const searchBox = document.getElementById('searchBox');
 const fileList = document.getElementById('fileList');
+
+function getFormattedDate() {
+  const date = new Date();
+  const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+  const months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+  const day = date.getDate();
+  const suffix = (day % 10 === 1 && day !== 11) ? 'st'
+                : (day % 10 === 2 && day !== 12) ? 'nd'
+                : (day % 10 === 3 && day !== 13) ? 'rd'
+                : 'th';
+  return `${days[date.getDay()]} ${day}${suffix} ${months[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+filenameInput.value = getFormattedDate();
+
+function toggleView() {
+  if (isPreview) {
+    previewDiv.style.display = 'none';
+    textarea.style.display = 'block';
+    toggleViewBtn.textContent = 'Preview Markdown';
+    isPreview = false;
+  } else {
+    previewDiv.innerHTML = marked.parse(textarea.value);
+    previewDiv.style.display = 'block';
+    textarea.style.display = 'none';
+    toggleViewBtn.textContent = 'Edit Markdown';
+    isPreview = true;
+  }
+}
+
+toggleViewBtn.addEventListener('click', toggleView);
 
 function saveNote() {
   const name = filenameInput.value.trim();

--- a/styles.css
+++ b/styles.css
@@ -22,10 +22,47 @@ textarea {
   transition: background-color 0.3s, color 0.3s;
 }
 
+#preview {
+  width: 100%;
+  max-width: 800px;
+  min-height: 400px;
+  padding: 10px;
+  font-size: 16px;
+  line-height: 1.5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  background-color: #fff;
+  color: #000;
+  overflow-y: auto;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.dark-mode #preview {
+  background-color: #2e2e2e;
+  color: #f0f0f0;
+  border: 1px solid #555;
+}
+
 button {
   cursor: pointer;
   background-color: transparent;
   border: none;
+}
+
+#toggle-view {
+  padding: 8px 12px;
+  margin-top: 10px;
+  background-color: #e0e0e0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: inherit;
+}
+
+.dark-mode #toggle-view {
+  background-color: #3a3a3a;
+  border: 1px solid #555;
+  color: #f0f0f0;
 }
 
 /* Dark mode */


### PR DESCRIPTION
## Summary
- default filenames use the current date
- include Marked.js and add preview div
- style preview area and preview button
- add markdown preview toggle logic
- document new features

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bdc5e7840832dbfb82f019adf3f10