### PR TITLE
Add delete note feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ A personal notes app that works in the browser.
 - Save your notes as a Markdown file. Specify a filename or use the default name based on today's date.
 - Save notes to your browser using localStorage and load them later.
 - Search through saved notes and download them all as a zip archive.
+- Delete notes from local storage when you no longer need them.
 - Toggle between editing and previewing your markdown.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     
         <button id="save-storage">Save</button>
         <button id="load-storage">Load</button>
+        <button id="delete-note">Delete</button>
         <button id="download-all">Download All Notes</button>
         <button id="toggle-view">Preview Markdown</button>
         

--- a/script.js
+++ b/script.js
@@ -26,6 +26,7 @@ const filenameInput = document.getElementById('filename-input');
 const saveStorageBtn = document.getElementById('save-storage');
 const loadStorageBtn = document.getElementById('load-storage');
 const downloadAllBtn = document.getElementById('download-all');
+const deleteBtn = document.getElementById('delete-note');
 const searchBox = document.getElementById('searchBox');
 const fileList = document.getElementById('fileList');
 
@@ -79,6 +80,24 @@ function loadNote() {
     return;
   }
   textarea.value = content;
+}
+
+function deleteNote() {
+  const name = filenameInput.value.trim();
+  if (!name) {
+    alert('Enter a filename.');
+    return;
+  }
+  if (localStorage.getItem('md_' + name) === null) {
+    alert('File not found.');
+    return;
+  }
+  if (!confirm('Delete this note?')) {
+    return;
+  }
+  localStorage.removeItem('md_' + name);
+  textarea.value = '';
+  updateFileList();
 }
 
 function downloadAllNotes() {
@@ -140,6 +159,7 @@ function filterNotes() {
 saveStorageBtn.addEventListener('click', saveNote);
 loadStorageBtn.addEventListener('click', loadNote);
 downloadAllBtn.addEventListener('click', downloadAllNotes);
+deleteBtn.addEventListener('click', deleteNote);
 searchBox.addEventListener('input', filterNotes);
 
 updateFileList();


### PR DESCRIPTION
## Summary
- add a Delete button in the UI
- implement `deleteNote` logic in JavaScript
- wire up a click handler for the new button
- document note deletion in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be22898f4832d8b61a917b74ed36c