### PR TITLE
Add new note button and autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ A personal notes app that works in the browser.
 - Search through saved notes and download them all as a zip archive.
 - Delete notes from local storage when you no longer need them.
 - Toggle between editing and previewing your markdown.
+- Create a new note which clears the editor.
+- Notes are automatically saved while you type.

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     
         <button id="save-storage">Save</button>
         <button id="load-storage">Load</button>
+        <button id="new-note">New Note</button>
         <button id="delete-note">Delete</button>
         <button id="download-all">Download All Notes</button>
         <button id="toggle-view">Preview Markdown</button>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const textarea = document.getElementById('editor');
 const previewDiv = document.getElementById('preview');
 const toggleViewBtn = document.getElementById('toggle-view');
 let isPreview = false;
+let autoSaveTimer = null;
 
 function applyTheme(theme) {
   document.body.classList.toggle('dark-mode', theme === 'dark');
@@ -25,6 +26,7 @@ const filenameInput = document.getElementById('filename-input');
 
 const saveStorageBtn = document.getElementById('save-storage');
 const loadStorageBtn = document.getElementById('load-storage');
+const newNoteBtn = document.getElementById('new-note');
 const downloadAllBtn = document.getElementById('download-all');
 const deleteBtn = document.getElementById('delete-note');
 const searchBox = document.getElementById('searchBox');
@@ -72,6 +74,13 @@ function saveNote() {
   updateFileList();
 }
 
+function autoSaveNote() {
+  const name = filenameInput.value.trim();
+  if (!name) return;
+  localStorage.setItem('md_' + name, textarea.value);
+  updateFileList();
+}
+
 function loadNote() {
   const name = filenameInput.value.trim();
   const content = localStorage.getItem('md_' + name);
@@ -80,6 +89,16 @@ function loadNote() {
     return;
   }
   textarea.value = content;
+}
+
+function newNote() {
+  textarea.value = '';
+  filenameInput.value = getFormattedDate();
+  if (isPreview) {
+    toggleView();
+  }
+  clearTimeout(autoSaveTimer);
+  updateFileList();
 }
 
 function deleteNote() {
@@ -156,8 +175,13 @@ function filterNotes() {
 
 saveStorageBtn.addEventListener('click', saveNote);
 loadStorageBtn.addEventListener('click', loadNote);
+newNoteBtn.addEventListener('click', newNote);
 downloadAllBtn.addEventListener('click', downloadAllNotes);
 deleteBtn.addEventListener('click', deleteNote);
 searchBox.addEventListener('input', filterNotes);
+textarea.addEventListener('input', () => {
+  clearTimeout(autoSaveTimer);
+  autoSaveTimer = setTimeout(autoSaveNote, 1000);
+});
 
 updateFileList();


### PR DESCRIPTION
## Summary
- add a `New Note` button to clear the editor
- support automatic saving while typing

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bf15a0548832d91b5e33fa1ba7ba4