### PR TITLE
Implement filename conflict warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ A personal notes app that works in the browser.
 - Toggle between editing and previewing your markdown.
 - Create a new note which clears the editor.
 - Notes are automatically saved while you type.
+- Prevent overwriting existing notes by warning when a filename is already in use.

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ const previewDiv = document.getElementById('preview');
 const toggleViewBtn = document.getElementById('toggle-view');
 let isPreview = false;
 let autoSaveTimer = null;
+let currentFileName = null;
 
 function applyTheme(theme) {
   document.body.classList.toggle('dark-mode', theme === 'dark');
@@ -70,14 +71,23 @@ function saveNote() {
     alert('Enter a filename.');
     return;
   }
+  if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
+    alert('A file with this name already exists. Please choose a different name.');
+    return;
+  }
   localStorage.setItem('md_' + name, content);
+  currentFileName = name;
   updateFileList();
 }
 
 function autoSaveNote() {
   const name = filenameInput.value.trim();
   if (!name) return;
+  if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
+    return;
+  }
   localStorage.setItem('md_' + name, textarea.value);
+  currentFileName = name;
   updateFileList();
 }
 
@@ -89,6 +99,7 @@ function loadNote() {
     return;
   }
   textarea.value = content;
+  currentFileName = name;
 }
 
 function newNote() {
@@ -98,6 +109,7 @@ function newNote() {
     toggleView();
   }
   clearTimeout(autoSaveTimer);
+  currentFileName = null;
   updateFileList();
 }
 
@@ -114,6 +126,7 @@ function deleteNote() {
   
   localStorage.removeItem('md_' + name);
   textarea.value = '';
+  currentFileName = null;
   updateFileList();
 }
 


### PR DESCRIPTION
## Summary
- warn before saving if a note with that filename already exists
- track the currently loaded filename and prevent autosave from overwriting
- document overwrite protection in README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bf2c528fc832dbed11248a4e982a3