### PR TITLE
Add todo list display

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,17 @@
     <textarea id="editor" placeholder="Start typing here..."></textarea>
     <div id="preview" style="display:none;"></div>
 
-    <h2>Saved Files</h2>
-    
-    <input type="text" id="searchBox" placeholder="Search notes...">
-    <ul id="fileList"></ul>
+    <div id="lists-container">
+      <div id="files-container">
+        <h2>Saved Files</h2>
+        <input type="text" id="searchBox" placeholder="Search notes...">
+        <ul id="fileList"></ul>
+      </div>
+      <div id="todo-container">
+        <h2>Todo Items</h2>
+        <ul id="todoList"></ul>
+      </div>
+    </div>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -32,6 +32,7 @@ const downloadAllBtn = document.getElementById('download-all');
 const deleteBtn = document.getElementById('delete-note');
 const searchBox = document.getElementById('searchBox');
 const fileList = document.getElementById('fileList');
+const todoList = document.getElementById('todoList');
 
 function getFormattedDate() {
   const date = new Date();
@@ -177,6 +178,38 @@ function updateFileList() {
           loadNote();
         };
         fileList.appendChild(li);
+      }
+    }
+  }
+
+  updateTodoList();
+}
+
+function updateTodoList() {
+  todoList.innerHTML = '';
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key.startsWith('md_')) {
+      const fileName = key.slice(3);
+      const lines = localStorage.getItem(key).split(/\n/);
+      const todos = lines.filter(line => line.trim().startsWith('- [ ]'));
+
+      if (todos.length > 0) {
+        const noteLi = document.createElement('li');
+        const title = document.createElement('strong');
+        title.textContent = fileName;
+        noteLi.appendChild(title);
+
+        const innerUl = document.createElement('ul');
+        todos.forEach(t => {
+          const todoLi = document.createElement('li');
+          todoLi.textContent = t.trim();
+          innerUl.appendChild(todoLi);
+        });
+
+        noteLi.appendChild(innerUl);
+        todoList.appendChild(noteLi);
       }
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -167,3 +167,19 @@ button {
   text-decoration: underline;
 }
 
+#lists-container {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+#todo-container ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#todo-container li {
+  margin-bottom: 4px;
+}
+
+


### PR DESCRIPTION
## Summary
- add column for saved files and to-do items in the UI
- update styles for side-by-side layout
- show open `- [ ]` tasks grouped by note

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bf6865634832db080e19527fd874e