### PR TITLE
Fix layout cutting off todo list

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -169,6 +169,7 @@ button {
 
 #lists-container {
   display: flex;
+  flex-direction: column;
   gap: 20px;
   align-items: flex-start;
 }


### PR DESCRIPTION
## Summary
- ensure todo list isn't cut off on wide screens by stacking list sections vertically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bfc980ed8832d8d50fb0367f71a1e