### PR TITLE
Adjust checklist rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -240,7 +240,12 @@ function updateTodoList() {
         const innerUl = document.createElement('ul');
         todos.forEach(t => {
           const todoLi = document.createElement('li');
-          todoLi.textContent = t.trim();
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.disabled = true;
+          todoLi.appendChild(checkbox);
+          const todoText = t.trim().replace(/^- \[ \]\s*/, '');
+          todoLi.appendChild(document.createTextNode(todoText));
           innerUl.appendChild(todoLi);
         });
 

--- a/styles.css
+++ b/styles.css
@@ -215,6 +215,11 @@ button {
   margin-top: 10px;
 }
 
+/* Remove bullet before task checkboxes in preview */
+#preview li.task-list-item {
+  list-style: none;
+}
+
 @media (min-width: 650px) {
   #lists-container {
     flex-direction: row;


### PR DESCRIPTION
## Summary
- show checkboxes in the Todo list preview instead of the raw `- [ ]` text
- remove bullets before task list items in the Markdown preview

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_685c22c669c8832da16572b6ddeb8f32