### PR TITLE
Fix link color in dark mode preview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,14 @@ textarea {
   color: #f0f0f0;
   border: 1px solid #555;
 }
+#preview a {
+  color: #0645ad;
+}
+
+.dark-mode #preview a {
+  color: #9cdcfe;
+}
+
 
 button {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- ensure markdown links are visible in dark mode

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c38747818832db82f211b555a0c9f