### PR TITLE
Fix preview not updating when loading notes

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,6 +104,9 @@ function loadNote() {
   }
   textarea.value = content;
   currentFileName = name;
+  if (isPreview) {
+    previewDiv.innerHTML = marked.parse(textarea.value);
+  }
 }
 
 function newNote() {


### PR DESCRIPTION
## Summary
- update preview in preview mode when loading a note

## Testing
- `npm test` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_685c41bd1a60832d8b20b04cd7a3217a