### PR TITLE
Fix auto-save duplicate notes when renaming

### DIFF
--- a/script.js
+++ b/script.js
@@ -110,13 +110,17 @@ function saveNote() {
 function autoSaveNote() {
   const name = getNoteTitle();
   if (!name) return;
-  if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
-    if (currentFileName && currentFileName !== name) {
-      localStorage.removeItem('md_' + currentFileName);
-    } else {
-      return;
-    }
+  if (currentFileName && currentFileName !== name) {
+    // Remove the old entry when the note title changes to avoid leaving
+    // partially typed titles in storage.
+    localStorage.removeItem('md_' + currentFileName);
   }
+
+  // If another note already exists with the new name, do not overwrite it.
+  if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
+    return;
+  }
+
   localStorage.setItem('md_' + name, textarea.value);
   currentFileName = name;
   updateFileList();


### PR DESCRIPTION
## Summary
- prevent auto-saving partial titles when typing first line

## Testing
- `node -p "require('./script.js'); console.log('Loaded');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685c4db3d61c832d80585da7b95321e9