### PR TITLE
Update note creation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A personal notes app that works in the browser.
 ## Features
 
 - Toggle between light and dark mode. Your choice is remembered between visits.
-- The first line of your note starting with `#` becomes its name and is pre-filled with today's date.
+- The first line of your note starting with `#` becomes its name and is pre-filled with today's date unless a note with today's date already exists.
 - Save notes to your browser using localStorage and load them later.
 - Search through saved notes and download them all as a zip archive.
 - Delete notes from local storage when you no longer need them.

--- a/script.js
+++ b/script.js
@@ -142,7 +142,13 @@ function loadNote(name) {
 }
 
 function newNote() {
-  textarea.value = '# ' + getFormattedDate() + '\n\n';
+  const today = getFormattedDate();
+  const key = 'md_' + today;
+  if (localStorage.getItem(key) === null) {
+    textarea.value = '# ' + today + '\n\n';
+  } else {
+    textarea.value = '';
+  }
   if (isPreview) {
     toggleView();
   }


### PR DESCRIPTION
## Summary
- document that automatic date header only happens if no note for today exists
- avoid date autofill when a note for the current date already exists

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c4f03a25c832da0c3a8bd9849cb91