### PR TITLE
Implement automatic unique note naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A personal notes app that works in the browser.
 ## Features
 
 - Toggle between light and dark mode. Your choice is remembered between visits.
-- The first line of your note starting with `#` becomes its name and is pre-filled with today's date unless a note with today's date already exists.
+- The first line of your note starting with `#` becomes its name and is pre-filled with today's date. If a note with that date already exists, a number is added automatically.
 - Save notes to your browser using localStorage and load them later.
 - Search through saved notes and download them all as a zip archive.
 - Delete notes from local storage when you no longer need them.
@@ -14,6 +14,6 @@ A personal notes app that works in the browser.
 - Check off tasks directly from preview mode.
 - Create a new note which clears the editor.
 - Notes are automatically saved while you type.
-- Prevent overwriting existing notes by warning when a note title is already in use.
+- Notes with duplicate titles are automatically given a numbered suffix so existing notes aren't overwritten.
 - View all unchecked tasks across notes in one list. Click a note title to open
   it and click a task checkbox to mark it complete.

--- a/script.js
+++ b/script.js
@@ -56,6 +56,16 @@ function getNoteTitle() {
   return null;
 }
 
+function ensureUniqueTitle(baseName) {
+  let name = baseName;
+  let counter = 1;
+  while (localStorage.getItem('md_' + name) !== null && name !== currentFileName) {
+    name = `${baseName} ${counter}`;
+    counter++;
+  }
+  return name;
+}
+
 
 function styleTaskListItems() {
   previewDiv.querySelectorAll('li').forEach(li => {
@@ -89,39 +99,52 @@ function toggleView() {
 toggleViewBtn.addEventListener('click', toggleView);
 
 function saveNote() {
-  const name = getNoteTitle();
-  const content = textarea.value;
+  let name = getNoteTitle();
   if (!name) {
     alert('The first line must start with # to provide a title.');
     return;
   }
-  if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
-    alert('A file with this name already exists. Please choose a different name.');
-    return;
+
+  let content = textarea.value;
+  const unique = ensureUniqueTitle(name);
+  if (unique !== name) {
+    const lines = content.split(/\n/);
+    lines[0] = '# ' + unique;
+    content = lines.join('\n');
+    textarea.value = content;
+    name = unique;
   }
+
   if (currentFileName && currentFileName !== name) {
     localStorage.removeItem('md_' + currentFileName);
   }
+
   localStorage.setItem('md_' + name, content);
   currentFileName = name;
   updateFileList();
 }
 
 function autoSaveNote() {
-  const name = getNoteTitle();
+  let name = getNoteTitle();
   if (!name) return;
+
   if (currentFileName && currentFileName !== name) {
     // Remove the old entry when the note title changes to avoid leaving
     // partially typed titles in storage.
     localStorage.removeItem('md_' + currentFileName);
   }
 
-  // If another note already exists with the new name, do not overwrite it.
-  if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
-    return;
+  let content = textarea.value;
+  const unique = ensureUniqueTitle(name);
+  if (unique !== name) {
+    const lines = content.split(/\n/);
+    lines[0] = '# ' + unique;
+    content = lines.join('\n');
+    textarea.value = content;
+    name = unique;
   }
 
-  localStorage.setItem('md_' + name, textarea.value);
+  localStorage.setItem('md_' + name, content);
   currentFileName = name;
   updateFileList();
 }
@@ -143,17 +166,13 @@ function loadNote(name) {
 
 function newNote() {
   const today = getFormattedDate();
-  const key = 'md_' + today;
-  if (localStorage.getItem(key) === null) {
-    textarea.value = '# ' + today + '\n\n';
-  } else {
-    textarea.value = '';
-  }
+  clearTimeout(autoSaveTimer);
+  currentFileName = null;
+  const unique = ensureUniqueTitle(today);
+  textarea.value = '# ' + unique + '\n\n';
   if (isPreview) {
     toggleView();
   }
-  clearTimeout(autoSaveTimer);
-  currentFileName = null;
   updateFileList();
 }
 


### PR DESCRIPTION
## Summary
- ensure new notes get unique titles
- auto-rename notes on save or autosave when a name is already taken
- update README with automatic renaming details

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c50a855c0832d8baf7ec45fb8dc12