### PR TITLE
Handle blank note title duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ A personal notes app that works in the browser.
 - Create a new note which clears the editor.
 - Notes are automatically saved while you type.
 - Prevent overwriting existing notes by warning when a note title is already in use.
+- If the note only contains a title that matches an existing note, that note opens automatically instead of showing a warning.
 - View all unchecked tasks across notes in one list. Click a note title to open
   it and click a task checkbox to mark it complete.

--- a/script.js
+++ b/script.js
@@ -62,6 +62,11 @@ function getNoteTitle() {
   return null;
 }
 
+function isNoteBodyEmpty() {
+  const lines = textarea.value.split(/\n/);
+  return lines.slice(1).join('\n').trim() === '';
+}
+
 
 function styleTaskListItems() {
   previewDiv.querySelectorAll('li').forEach(li => {
@@ -102,7 +107,12 @@ function saveNote() {
     return;
   }
   if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
-    updateStatus(`File not saved. A file named "${name}" already exists. Please rename.`, false);
+    if (isNoteBodyEmpty()) {
+      loadNote(name);
+      updateStatus(`Opened existing note "${name}".`, true);
+    } else {
+      updateStatus(`File not saved. A file named "${name}" already exists. Please rename.`, false);
+    }
     return;
   }
   if (currentFileName && currentFileName !== name) {
@@ -125,7 +135,12 @@ function autoSaveNote() {
 
   // If another note already exists with the new name, do not overwrite it.
   if (localStorage.getItem('md_' + name) !== null && currentFileName !== name) {
-    updateStatus(`File not saved. A file named "${name}" already exists. Please rename.`, false);
+    if (isNoteBodyEmpty()) {
+      loadNote(name);
+      updateStatus(`Opened existing note "${name}".`, true);
+    } else {
+      updateStatus(`File not saved. A file named "${name}" already exists. Please rename.`, false);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- add helper `isNoteBodyEmpty`
- when saving or autosaving, open existing note instead of warning if body is empty
- document this behavior in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c5da1ba44832d9904af5d9ebe9df8