### PR TITLE
Pastel pink light mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 body {
-  background-color: #e5f6ff; /* light baby blue */
+  background-color: #ffe6f2; /* pastel pink */
   font-family: Arial, sans-serif;
   padding: 20px;
   color: #333;
@@ -14,11 +14,11 @@ textarea {
   margin-top: 10px;
   font-size: 16px;
   line-height: 1.5;
-  border: 1px solid #a3d4ff;
+  border: 1px solid #f5c0d6;
   border-radius: 4px;
   box-sizing: border-box;
   resize: vertical;
-  background-color: #f8fbff;
+  background-color: #fff5fa;
   color: #000;
   transition: background-color 0.3s, color 0.3s;
 }
@@ -30,10 +30,10 @@ textarea {
   padding: 10px;
   font-size: 16px;
   line-height: 1.5;
-  border: 1px solid #a3d4ff;
+  border: 1px solid #f5c0d6;
   border-radius: 4px;
   box-sizing: border-box;
-  background-color: #f8fbff;
+  background-color: #fff5fa;
   color: #000;
   overflow-y: auto;
   transition: background-color 0.3s, color 0.3s;
@@ -62,8 +62,8 @@ button {
 #toggle-view {
   padding: 8px 12px;
   margin-top: 10px;
-  background-color: #cfe8ff;
-  border: 1px solid #a3d4ff;
+  background-color: #ffd6e7;
+  border: 1px solid #f5c0d6;
   border-radius: 4px;
   color: inherit;
 }
@@ -112,8 +112,8 @@ button {
   padding: 8px 12px;
   margin-right: 5px;
   margin-bottom: 10px;
-  background-color: #cfe8ff;
-  border: 1px solid #a3d4ff;
+  background-color: #ffd6e7;
+  border: 1px solid #f5c0d6;
   border-radius: 4px;
   color: inherit;
 }
@@ -135,9 +135,9 @@ button {
   padding: 8px;
   font-size: 16px;
   width: 300px;
-  border: 1px solid #a3d4ff;
+  border: 1px solid #f5c0d6;
   border-radius: 4px;
-  background-color: #f8fbff;
+  background-color: #fff5fa;
   color: #000;
   transition: background-color 0.3s, color 0.3s, border-color 0.3s;
 }
@@ -160,7 +160,7 @@ button {
 
 #fileList li.active-file {
   font-weight: bold;
-  color: #8a5a00 ;
+  color: #d16d9b;
 }
 
 .dark-mode #fileList li.active-file {


### PR DESCRIPTION
## Summary
- soften the default light theme with a pastel pink palette
- adjust textarea, preview, search box and buttons to use the lighter colors
- highlight the active file using a matching pink tint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c647cd5b4832d8254cafb2c10d039