### PR TITLE
Change default theme to dark

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
   
 </head>
 
-<body>
+<body class="dark-mode">
 
-    <button id="toggle-theme" class="sun" aria-label="Toggle Dark Mode"></button>
+    <button id="toggle-theme" class="moon" aria-label="Toggle Dark Mode"></button>
     
     <div id="status-message"></div>    
   

--- a/script.js
+++ b/script.js
@@ -20,7 +20,7 @@ function toggleTheme() {
 
 toggleBtn.addEventListener('click', toggleTheme);
 
-const savedTheme = localStorage.getItem('theme') || 'light';
+const savedTheme = localStorage.getItem('theme') || 'dark';
 applyTheme(savedTheme);
 
 


### PR DESCRIPTION
## Summary
- enable dark mode by default in the notes app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d218794d4832d9219ff28bc3420c4