### PR TITLE
Fix task list text wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -214,6 +214,17 @@ button {
   margin-top: 4px;
 }
 
+/* Align multi-line tasks with their text rather than the checkbox */
+#todoList li li {
+  display: flex;
+  align-items: flex-start;
+}
+
+#todoList li li input[type="checkbox"] {
+  margin-right: 6px;
+  margin-top: 2px;
+}
+
 #todo-container strong {
   display:block;
   margin-bottom: 10px;


### PR DESCRIPTION
## Summary
- align todo items so wrapped lines line up with text instead of the checkbox

## Testing
- `npx eslint --version` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_685d2c2df8bc832d8e3ebceb1c8b9562