### PR TITLE
Fix task indent in preview

### DIFF
--- a/script.js
+++ b/script.js
@@ -73,6 +73,13 @@ function styleTaskListItems(container = previewDiv) {
     const checkbox = li.querySelector('input[type="checkbox"]');
     if (checkbox) {
       li.style.listStyleType = 'none';
+      li.style.marginLeft = '0';
+      li.style.paddingLeft = '0';
+      const parent = li.parentElement;
+      if (parent && (parent.tagName === 'UL' || parent.tagName === 'OL')) {
+        parent.style.marginLeft = '0';
+        parent.style.paddingLeft = '0';
+      }
       if (!checkbox.nextSibling || checkbox.nextSibling.nodeValue !== ' ') {
         checkbox.insertAdjacentText('afterend', ' ');
       }


### PR DESCRIPTION
## Summary
- update `styleTaskListItems` to remove list padding for preview tasks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d41ccc018832da43bc138e80e61b7