### PR TITLE
Fix bullet spacing in mixed markdown lists

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,6 +86,12 @@ function styleTaskListItems(container = previewDiv) {
       checkbox = firstChild.firstElementChild;
       firstChild.style.margin = '0';
       firstChild.style.display = 'inline';
+    } else if (
+      firstChild &&
+      firstChild.tagName === 'P' &&
+      li.childElementCount === 1
+    ) {
+      firstChild.style.margin = '0';
     }
 
     if (checkbox) {

--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,9 @@ textarea {
   color: #f0f0f0;
   border: 1px solid #555;
 }
+#preview li p:first-child:last-child {
+  margin: 0;
+}
 #preview a {
   color: #0645ad;
 }


### PR DESCRIPTION
## Summary
- remove gap around single-paragraph list items in preview
- ensure JS removes `<p>` margins in preview rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d5fcbe23c832db916d9176b9c587f