### PR TITLE
Improve spacing for mixed lists

### DIFF
--- a/script.js
+++ b/script.js
@@ -71,6 +71,9 @@ function isNoteBodyEmpty() {
 
 function styleTaskListItems(container = previewDiv) {
   container.querySelectorAll('li').forEach(li => {
+    li.classList.remove('task-item', 'bullet-item');
+    li.style.marginTop = '';
+
     const firstChild = li.firstElementChild;
     let checkbox = null;
 
@@ -97,6 +100,8 @@ function styleTaskListItems(container = previewDiv) {
     if (checkbox) {
       li.style.listStyleType = 'none';
 
+      li.classList.add('task-item');
+
       // remove the indentation applied by the parent list while keeping
       // the indentation for non-checkbox items intact
       const parent = li.parentElement;
@@ -117,6 +122,8 @@ function styleTaskListItems(container = previewDiv) {
       if (!checkbox.nextSibling || checkbox.nextSibling.nodeValue !== ' ') {
         checkbox.insertAdjacentText('afterend', ' ');
       }
+    } else {
+      li.classList.add('bullet-item');
     }
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -250,6 +250,14 @@ button {
   border-top: 1px solid #a272b0;
 }
 
+/* Add spacing between checklist and bullet items within the same list */
+#preview li.task-item + li.bullet-item,
+#preview li.bullet-item + li.task-item,
+#todoList li.task-item + li.bullet-item,
+#todoList li.bullet-item + li.task-item {
+  margin-top: 8px;
+}
+
 @media (min-width: 650px) {
   #lists-container {
     flex-direction: row;


### PR DESCRIPTION
## Summary
- tag checklist items with `task-item` class
- mark other list items as `bullet-item`
- add CSS to create a gap between bullet and checklist items

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d68efd648832d9b4ae2e60f517a33