### PR TITLE
Fix favicon link quoting

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Notes App</title>
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" href="001_Assets/favicon.ico" type="image/x-icon>
+    <link rel="icon" href="001_Assets/favicon.ico" type="image/x-icon">
     <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   


### PR DESCRIPTION
## Summary
- close favicon link attribute quote so subsequent scripts load properly

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d9ab463dc832d8670efe077775902