### PR TITLE
Add note linking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ A personal notes app that works in the browser.
 - If the note only contains a title that matches an existing note, that note opens automatically instead of showing a warning.
 - View all unchecked tasks across notes in one list. Click a note title to open
   it and click a task checkbox to mark it complete.
+- Link to other notes using standard Markdown link syntax, e.g. `[Note](My Note)`.

--- a/script.js
+++ b/script.js
@@ -128,6 +128,25 @@ function styleTaskListItems(container = previewDiv) {
   });
 }
 
+function setupNoteLinks(container = previewDiv) {
+  container.querySelectorAll('a').forEach(a => {
+    const href = a.getAttribute('href');
+    if (!href || href.startsWith('#') || /^[a-zA-Z]+:/.test(href)) {
+      return;
+    }
+    const noteName = decodeURIComponent(href);
+    a.href = '#';
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      if (localStorage.getItem('md_' + noteName) !== null) {
+        loadNote(noteName);
+      } else {
+        alert(`Note "${noteName}" not found.`);
+      }
+    });
+  });
+}
+
 function toggleView() {
   if (isPreview) {
     previewDiv.style.display = 'none';
@@ -138,6 +157,7 @@ function toggleView() {
   } else {
     previewDiv.innerHTML = marked.parse(textarea.value);
     styleTaskListItems(previewDiv);
+    setupNoteLinks(previewDiv);
     setupPreviewTaskCheckboxes();
     previewDiv.style.display = 'block';
     textarea.style.display = 'none';
@@ -189,6 +209,7 @@ function loadNote(name) {
   if (isPreview) {
     previewDiv.innerHTML = marked.parse(textarea.value);
     styleTaskListItems(previewDiv);
+    setupNoteLinks(previewDiv);
     setupPreviewTaskCheckboxes();
   }
   updateFileList();
@@ -372,6 +393,7 @@ function updateTodoList() {
     }
   }
   styleTaskListItems(todoList);
+  setupNoteLinks(todoList);
 }
 
 function setupPreviewTaskCheckboxes() {
@@ -398,6 +420,7 @@ function setupPreviewTaskCheckboxes() {
         }
         previewDiv.innerHTML = marked.parse(textarea.value);
         styleTaskListItems(previewDiv);
+        setupNoteLinks(previewDiv);
         setupPreviewTaskCheckboxes();
         updateTodoList();
       }
@@ -418,6 +441,7 @@ function toggleTaskStatus(fileName, lineIndex) {
       if (isPreview) {
         previewDiv.innerHTML = marked.parse(textarea.value);
         styleTaskListItems(previewDiv);
+        setupNoteLinks(previewDiv);
         setupPreviewTaskCheckboxes();
       }
     }


### PR DESCRIPTION
## Summary
- enable linking to notes via standard Markdown links
- document note linking in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e6ef6cf98832d8031e3af218713d4