### PR TITLE
Improve note link handling for spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ A personal notes app that works in the browser.
 - View all unchecked tasks across notes in one list. Click a note title to open
   it and click a task checkbox to mark it complete.
 - Link to other notes using standard Markdown link syntax, e.g. `[Note](My Note)`.
+  Links also work for note names containing spaces.

--- a/script.js
+++ b/script.js
@@ -134,7 +134,7 @@ function setupNoteLinks(container = previewDiv) {
     if (!href || href.startsWith('#') || /^[a-zA-Z]+:/.test(href)) {
       return;
     }
-    const noteName = decodeURIComponent(href);
+    const noteName = decodeURIComponent(href).replace(/\+/g, ' ').trim();
     a.href = '#';
     a.addEventListener('click', e => {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- ensure links to notes decode `+` to spaces and trim whitespace
- document that note links work with spaces

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_685e72fd0984832d9aa462a7f1521ce6