### PR TITLE
Reverse internal note link chain

### DIFF
--- a/script.js
+++ b/script.js
@@ -141,7 +141,9 @@ function setupNoteLinks(container = previewDiv) {
       e.preventDefault();
       if (localStorage.getItem('md_' + noteName) !== null) {
         if (currentFileName && !linkedNoteChain.includes(currentFileName)) {
-          linkedNoteChain.push(currentFileName);
+          // Add the previously viewed note to the top of the chain so the
+          // history is ordered from most recent to oldest.
+          linkedNoteChain.unshift(currentFileName);
         }
         loadNote(noteName, true);
       } else {


### PR DESCRIPTION
## Summary
- reverse the link chain order so the most recently clicked note is listed first

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685e7c61edc0832db456e9a51ae44cd1