### PR TITLE
Fix NOT operator handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,8 +89,10 @@ function createSearchPredicate(query) {
 
   function parseTerm() {
     let left = parseFactor();
-    while (tokens[index] && tokens[index].toUpperCase() === 'AND') {
-      index++;
+    while (tokens[index] && tokens[index].toUpperCase() !== 'OR') {
+      if (tokens[index].toUpperCase() === 'AND') {
+        index++;
+      }
       const right = parseFactor();
       const prev = left;
       left = (n, c) => prev(n, c) && right(n, c);


### PR DESCRIPTION
## Summary
- support implicit `AND` logic in search

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_685e81b4aea4832db88db2b5916b7552