### PR TITLE
Adjust notes list spacing in widescreen

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -303,4 +303,17 @@ button {
   }
 }
 
+@media (min-width: 1500px) {
+  #layout-wrapper {
+    gap: 0;
+  }
+  #editor-section {
+    margin-right: 0;
+  }
+  #lists-container {
+    margin-left: 40px;
+    margin-right: 0;
+  }
+}
+
 


### PR DESCRIPTION
## Summary
- add a new 1500px media query overriding spacing
- keep notes/tasks list container 40px away from the editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ea1e2e37c832d868e5b99d65950de