### PR TITLE
Fix lists container spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -309,6 +309,7 @@ button {
   }
   #editor-section {
     margin-right: 0;
+    flex: 0;
   }
   #lists-container {
     margin-left: 40px;


### PR DESCRIPTION
## Summary
- align saved notes/tasks container next to the editor on large screens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ea4836270832dad8869845615703a