### PR TITLE
Organize button menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,15 +30,25 @@
   
     <div class="storage-controls">
 
-        <button id="new-note">New Note</button>
-        <button id="delete-note">Delete Note</button>
-        <button id="delete-all">Delete All Notes</button>
-        <button id="download-all">Download All Notes</button>
-        <button id="export-note">Export Note</button>
-        <button id="export-all-html">Export All Notes</button>
-        <button id="import-zip">Import Notes</button>
+        <div class="button-group">
+            <button id="new-note">New Note</button>
+        </div>
+        <div class="button-group">
+            <button id="delete-note">Delete Note</button>
+            <button id="delete-all" class="sub-button">Delete All Notes</button>
+        </div>
+        <div class="button-group">
+            <button id="export-note">Export Note</button>
+            <button id="export-all-html" class="sub-button">Export All Notes</button>
+        </div>
+        <div class="button-group">
+            <button id="import-zip">Import Notes</button>
+            <button id="download-all" class="sub-button">Backup Notes</button>
+        </div>
         <input type="file" id="import-zip-input" accept=".zip" style="display:none;">
-        <button id="toggle-view">Preview Markdown</button>
+        <div class="button-group">
+            <button id="toggle-view">Preview Markdown</button>
+        </div>
 
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -140,6 +140,32 @@ button {
   color: #f0f0f0;
 }
 
+/* Button groups for condensed controls */
+.storage-controls .button-group {
+  position: relative;
+  display: inline-block;
+}
+
+.storage-controls .button-group .sub-button {
+  display: none;
+  position: absolute;
+  left: 0;
+  top: 100%;
+  margin-top: 2px;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.storage-controls .button-group:hover .sub-button {
+  display: block;
+}
+
+.dark-mode .storage-controls .button-group .sub-button {
+  background-color: #3a3a3a;
+  border: 1px solid #555;
+  color: #f0f0f0;
+}
+
 #searchBox {
   display: block;
   margin: 10px 0;


### PR DESCRIPTION
## Summary
- organize the main action buttons into hoverable groups
- rename "Download All Notes" to "Backup Notes"
- add CSS rules for hover dropdown buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ea6da0000832d82b3291242734f9b