### PR TITLE
Fix button styles and mobile logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -625,8 +625,8 @@ function setupMobileButtonGroup(button, action) {
   }
 
   button.addEventListener('click', e => {
-    const isTouch = window.matchMedia('(hover: none)').matches;
-    if (isTouch && !group.classList.contains('active')) {
+    const isMobileTouch = window.matchMedia('(hover: none) and (max-width: 650px)').matches;
+    if (isMobileTouch && !group.classList.contains('active')) {
       e.preventDefault();
       group.classList.add('active');
       const hide = evt => {

--- a/styles.css
+++ b/styles.css
@@ -144,9 +144,6 @@ button {
 .storage-controls .button-group {
   position: relative;
   display: inline-block;
-  background-color: #d8bbdf;
-  border: 1px solid #a272b0;
-  border-radius: 4px;
   margin-right: 5px;
   margin-bottom: 10px;
 }
@@ -156,7 +153,8 @@ button {
   position: absolute;
   left: 0;
   top: 100%;
-  margin-top: 2px;
+  margin-top: 0;
+  padding-top: 2px;
   white-space: nowrap;
   z-index: 10;
 }
@@ -167,11 +165,6 @@ button {
 
 .storage-controls .button-group.active .sub-button {
   display: block;
-}
-
-.dark-mode .storage-controls .button-group {
-  background-color: #3a3a3a;
-  border: 1px solid #555;
 }
 
 .dark-mode .storage-controls .button-group .sub-button {


### PR DESCRIPTION
## Summary
- remove background on button groups
- prevent gap below top button with padding
- only use click dropdowns when on small touch devices

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685eaf9d8430832da06ecfb6ea6bcda9