### PR TITLE
Add missing note title warning

### DIFF
--- a/script.js
+++ b/script.js
@@ -232,7 +232,10 @@ toggleViewBtn.addEventListener('click', toggleView);
 
 function autoSaveNote() {
   const name = getNoteTitle();
-  if (!name) return;
+  if (!name) {
+    updateStatus('File not saved. Please add a title starting with "#".', false);
+    return;
+  }
   if (currentFileName && currentFileName !== name) {
     // Remove the old entry when the note title changes to avoid leaving
     // partially typed titles in storage.


### PR DESCRIPTION
## Summary
- warn if auto-saving without a note title

## Testing
- `npx eslint` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_685ebab77368832d9a661996f644d7c4