### PR TITLE
Truncate long note names in list

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -217,6 +217,11 @@ button {
 #fileList li {
   cursor: pointer;
   margin-bottom: 4px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
 }
 
 #fileList li.active-file {


### PR DESCRIPTION
## Summary
- prevent saved note names from spilling onto more than two lines by clamping them in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ebd2f52a8832daee6e71c12313ddb