### PR TITLE
Move selected note buttons into button groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,14 +35,17 @@
         </div>
         <div class="button-group">
             <button id="delete-note">Delete Note</button>
+            <button id="delete-selected" class="sub-button">Delete Selected Notes</button>
             <button id="delete-all" class="sub-button">Delete All Notes</button>
         </div>
         <div class="button-group">
             <button id="export-note">Export Note</button>
+            <button id="export-selected" class="sub-button">Export Selected Notes</button>
             <button id="export-all-html" class="sub-button">Export All Notes</button>
         </div>
         <div class="button-group">
             <button id="import-zip">Import Notes</button>
+            <button id="backup-selected" class="sub-button">Backup Selected Notes</button>
             <button id="download-all" class="sub-button">Backup Notes</button>
         </div>
         <input type="file" id="import-zip-input" accept=".zip" style="display:none;">
@@ -62,11 +65,6 @@
         <div id="files-container">
           <h2>Saved Notes</h2>
           <input type="text" id="searchBox" placeholder="Search Notes...">
-          <div class="list-controls">
-            <button id="delete-selected">Delete Selected Notes</button>
-            <button id="export-selected">Export Selected Notes</button>
-            <button id="backup-selected">Backup Selected Notes</button>
-          </div>
           <ul id="fileList"></ul>
         </div>
         <div id="todo-container">

--- a/styles.css
+++ b/styles.css
@@ -142,46 +142,23 @@ button {
 /* Button groups for condensed controls */
 .storage-controls .button-group {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  flex-direction: column;
   margin-right: 5px;
   margin-bottom: 10px;
 }
 
 .storage-controls .button-group .sub-button {
   display: none;
-  position: absolute;
-  left: 0;
-  top: 100%;
-  margin-top: 0;
-  white-space: nowrap;
-  z-index: 10;
+  margin-top: 5px;
 }
 
-.storage-controls .button-group:hover .sub-button {
-  display: block;
-}
-
+.storage-controls .button-group:hover .sub-button,
 .storage-controls .button-group.active .sub-button {
-  display: block;
+  display: inline-block;
 }
 
 .dark-mode .storage-controls .button-group .sub-button {
-  background-color: #3a3a3a;
-  border: 1px solid #555;
-  color: #f0f0f0;
-}
-
-.list-controls button {
-  padding: 8px 12px;
-  margin-right: 5px;
-  margin-bottom: 10px;
-  background-color: #d8bbdf;
-  border: 1px solid #a272b0;
-  border-radius: 4px;
-  color: inherit;
-}
-
-.dark-mode .list-controls button {
   background-color: #3a3a3a;
   border: 1px solid #555;
   color: #f0f0f0;


### PR DESCRIPTION
## Summary
- move Delete Selected, Export Selected, and Backup Selected into the respective storage-control groups
- clean up related CSS styling and allow multiple sub-buttons to stack vertically

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ec62aca80832d971b015c008b7626