### PR TITLE
Add project utilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 <title>Projects App</title>
 <link rel = "stylesheet" href = "styles.css">
 <link rel = "icon" href = "001_Assets/favicon.ico" type="image/x-icon">
+<script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src = "script.js"></script>
 </head>
 
@@ -45,6 +47,7 @@
 
 <div class = "button-group">
 <button id = "import-note">Import Projects</button>
+<input type="file" id="import-file" style="display:none" accept="application/json">
 </div>
 
 <div class = "button-group">


### PR DESCRIPTION
## Summary
- load JSZip and Marked libraries
- add hidden file input for importing
- implement project management features: delete/export/backup/import/preview
- wire up buttons to new actions
- export projects as HTML including calendar snapshots

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6882687ea774832d9c4241535d165711