### PR TITLE
Update features: remove export, add markdown preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,11 +34,9 @@
 </div>
 
 <div class = "button-group">
-<button id = "export-files">Export Projects</button>
+<button id = "export-files">Backup Projects</button>
 
 <div class = "sub-button">
-<button id = "export-all-files">Export All Projects</button>
-<button id = "export-visible-files">Export Visible Projects</button>
 <button id = "backup-all-files">Backup All Projects</button>
 <button id = "backup-visible-files">Backup Visible Projects</button>
 
@@ -59,6 +57,7 @@
 <div id = "layout-wrapper">
 
 <textarea id = "editor" placeholder = "Start Typing Here...\n# Project Title"></textarea>
+<div id="preview" style="display:none"></div>
 
 <div id = widget-container>
 

--- a/styles.css
+++ b/styles.css
@@ -164,6 +164,22 @@ font-family: Arial, sans-serif;
 
 }
 
+#preview {
+background-color: #2e2e2e;
+color: #f0f0f0;
+border: 1px solid #555;
+border-radius: 4px;
+width: 100%;
+max-width: 800px;
+box-sizing: border-box;
+min-height: 400px;
+padding: 10px;
+margin: 10px;
+font-size: 16px;
+font-family: Arial, sans-serif;
+overflow-y: auto;
+}
+
 /* Calendar CSS Here */
 
 #calendar {


### PR DESCRIPTION
## Summary
- remove HTML export options and rename group button to 'Backup Projects'
- drop export logic from script.js
- add live markdown preview toggle
- style preview container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68827cbbd5fc832db9d96cf625de520c