### PR TITLE
Fix preview state when starting a new project

### DIFF
--- a/script.js
+++ b/script.js
@@ -399,6 +399,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function disablePreview() {
+        if (previewActive) {
+            previewDiv.style.display = 'none';
+            editor.style.display = 'block';
+            previewBtn.textContent = 'Preview Markdown';
+            previewActive = false;
+        }
+    }
+
 
     function renderCalendar(projects, target = calendar) {
         target.innerHTML = '';
@@ -559,9 +568,7 @@ new Date(year, m).toLocaleString('default',{month:'long'})
         renderCalendar([]);
         updateProjectList();
         updateStatus('Enter project title on the first line starting with "#".', false);
-        if (previewActive) {
-            renderPreview();
-        }
+        disablePreview();
     });
 
     deleteCurrentBtn.addEventListener('click', deleteCurrentProject);


### PR DESCRIPTION
## Summary
- add `disablePreview` helper to hide preview pane
- use `disablePreview` when creating a new project to exit preview mode

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_68829dd190ac832da4bf2dac170a8359