### PR TITLE
Fix offline strikethrough in markdown preview

### DIFF
--- a/script.js
+++ b/script.js
@@ -506,7 +506,14 @@ document.addEventListener('DOMContentLoaded', () => {
         if (typeof marked !== 'undefined') {
             html = marked.parse(text);
         } else {
-            html = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\n/g, '<br>');
+            html = text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+            html = html
+                .replace(/&lt;(\/?)del&gt;/g, '<$1del>')
+                .replace(/&lt;(\/?)span([^&]*)&gt;/g, '<$1span$2>')
+                .replace(/\n/g, '<br>');
         }
         previewDiv.innerHTML = html;
     }


### PR DESCRIPTION
## Summary
- correctly render `<del>` and `<span>` tags when the marked library isn't loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882a814f0d4832d99f3b4ccdf9019ee