### PR TITLE
Ensure consistent status messages

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,8 +35,15 @@ document.addEventListener('DOMContentLoaded', () => {
         return `hsl(${h},${s}%,${l}%)`;
     }
 
+    function toTitleCase(str) {
+        return str.replace(/\w\S*/g, (w) =>
+            w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
+        );
+    }
+
     function updateStatus(message, success) {
-        statusDiv.textContent = message;
+        const formatted = message ? toTitleCase(message) : '';
+        statusDiv.textContent = formatted;
         statusDiv.style.color = success ? 'green' : 'red';
     }
 

--- a/script_old.js
+++ b/script_old.js
@@ -66,8 +66,15 @@ function getVisibleNotes() {
   return notes;
 }
 
+function toTitleCase(str) {
+  return str.replace(/\w\S*/g, (w) =>
+    w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
+  );
+}
+
 function updateStatus(message, success) {
-  statusDiv.textContent = message;
+  const formatted = message ? toTitleCase(message) : '';
+  statusDiv.textContent = formatted;
   statusDiv.style.color = success ? 'green' : 'red';
 }
 

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,8 @@ flex-direction: column-reverse;
   margin-bottom: 10px;
   margin-left: 10px;
   font-weight: bold;
+  padding: 5px 10px;
+  min-height: 1em;
 }
 
 #layout-wrapper {


### PR DESCRIPTION
## Summary
- convert status messages to title case in both scripts
- keep padding visible even when no message is displayed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882aa9d1b60832d96451006d997c429