### PR TITLE
Prevent duplicate project names

### DIFF
--- a/script.js
+++ b/script.js
@@ -145,6 +145,10 @@ document.addEventListener('DOMContentLoaded', () => {
             updateStatus('The selected name is reserved.', false);
             return;
         }
+        if (currentProject !== name && localStorage.getItem('project_' + name) !== null) {
+            updateStatus('A Project With That Name Already Exists.', false);
+            return;
+        }
         if (currentProject && currentProject !== name) {
             localStorage.removeItem('project_' + currentProject);
         }


### PR DESCRIPTION
## Summary
- prevent saving projects with duplicate names
- apply title case to duplicate name warning

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68833dd15dec832d9b2ba94d7db13346