### PR TITLE
Fix search to treat spaces as phrases

### DIFF
--- a/script.js
+++ b/script.js
@@ -163,6 +163,12 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!query) return () => true;
 
         const tokens = query.match(/"[^"]+"|\S+/g) || [];
+        const hasOps = tokens.some(t => ['AND', 'OR', 'NOT'].includes(t.toUpperCase()));
+        if (!hasOps && tokens.length > 1) {
+            const phrase = query.toLowerCase();
+            return (n, c) => n.includes(phrase) || c.includes(phrase);
+        }
+
         let index = 0;
 
         function parseExpression() {


### PR DESCRIPTION
## Summary
- updated search predicate to detect boolean operators
- if query lacks operators, treat spaces as a single phrase

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688345bad2e4832d81a9b17fe2cd2559