### PR TITLE
Allow calendar bar navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -266,6 +266,6 @@ z-index: 1;
 }
 
 .bar {
-flex: 1;
-cursor: default;
+    flex: 1;
+    cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- store project owner when parsing projects
- allow opening a project when clicking its bar in the calendar
- include owner when updating calendar views
- make calendar bars use a pointer cursor

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688a20b8c178832da7f7cddd5cde152a