### PR TITLE
Enable independent scrolling on widescreen layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -269,3 +269,43 @@ z-index: 1;
     flex: 1;
     cursor: pointer;
 }
+
+/* Independent scrolling for widescreen layouts */
+@media (min-width: 1501px) {
+    body {
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    #layout-wrapper {
+        flex: 1;
+        display: flex;
+        overflow: hidden;
+    }
+
+    #editor,
+    #preview {
+        height: 100%;
+        overflow-y: auto;
+    }
+
+    #widget-container {
+        flex: 1;
+        display: flex;
+        overflow: hidden;
+    }
+
+    #calendar {
+        height: 100%;
+        overflow-y: auto;
+        flex-shrink: 0;
+    }
+
+    #project-container {
+        flex: 1;
+        height: 100%;
+        overflow-y: auto;
+    }
+}


### PR DESCRIPTION
## Summary
- prevent body scrolling and give layout columns their own scroll behavior in widescreen view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e4c536334832da2a7187dda47985d