### PR TITLE
Remove scrolling on text area and hide scrollbars

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
     const editor = document.getElementById('editor');
     editor.readOnly = false;
+    // Prevent mouse wheel from scrolling inside the text area
+    editor.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        window.scrollBy(0, e.deltaY);
+    }, { passive: false });
     const calendar = document.getElementById('calendar');
     const newFileBtn = document.getElementById('new-file');
     const projectList = document.getElementById('saved-projects-list');

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,15 @@ color: #f0f0f0;
 font-family: Arial, sans-serif;
 }
 
+/* Hide scrollbars for all elements */
+* {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE and Edge */
+}
+*::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+}
+
 @media (max-width: 1500px){
 
 #layout-wrapper {


### PR DESCRIPTION
## Summary
- Disable mouse wheel scrolling inside the editor textarea so the page scrolls instead.
- Hide scrollbars across the app for a cleaner UI.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906e531b68832db61527303e5009fb