### PR TITLE
fix: enable textarea scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,7 @@ textarea {
   border-radius: 4px;
   box-sizing: border-box;
   resize: vertical;
+  overflow-y: auto;
   background-color: #d8bbdf;
   color: #000;
   transition: background-color 0.3s, color 0.3s;


### PR DESCRIPTION
## Summary
- ensure note editor's textarea can scroll by explicitly setting `overflow-y:auto`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b80f876390832dadd73d9b2d6155aa