### PR TITLE
Remove last-backed-up pill message; fix pill width adaption across platforms

### DIFF
--- a/web/app-init.js
+++ b/web/app-init.js
@@ -408,7 +408,6 @@ function showPanel(force = false) {
   panelLists.classList.add('visible');
   document.body.classList.add('panel-visible');
   checkToolbarOverflow();
-  updateBackupStatus();
 }
 
 function scheduleHidePanel() {
@@ -428,9 +427,6 @@ panelLists.addEventListener('mouseenter', showPanel);
 panelLists.addEventListener('mouseleave', scheduleHidePanel);
 
 applyPinState();
-updateBackupStatus();
-
-setInterval(updateBackupStatus, 3600000);
 
 // Restore the last active panel
 {
@@ -848,7 +844,6 @@ const _RE_AC_MD   = /\[[^\[\]\n]*\]\(([^)\n]*)$/;
     activateNotesInLeftPanel();
     panelLists.classList.add('mobile-open-left');
     mobileOverlay.classList.add('active');
-    updateBackupStatus();
   }
 
   function openRightPanel() {
@@ -975,10 +970,6 @@ if (typeof BroadcastChannel !== 'undefined' && !window.electronAPI && !window.Ca
 
 // ── Cross-window sync via storage events ──────────────────────────────────
 window.addEventListener('storage', e => {
-  if (e.key === 'last_backup_time') {
-    updateBackupStatus();
-    return;
-  }
   // Re-apply theme/calendar colours when changed in another tab
   if (e.key === 'app_theme' || e.key === 'calendar_colors' || e.key === 'project_emojis') {
     if (e.key === 'app_theme') {
@@ -1184,7 +1175,6 @@ function _setupPowerSyncHandlers() {
   if (bottomArea) {
     bottomArea.style.cursor = 'pointer';
     bottomArea.title = 'Tap to sync';
-    updateBackupStatus(); // Refresh to show "· Tap to Sync" hint on iOS
     bottomArea.addEventListener('click', async () => {
       if (autoSaveTimer !== null) {
         clearTimeout(autoSaveTimer);
@@ -1223,7 +1213,6 @@ if (window.Capacitor?.isNativePlatform()) {
     if (!bottomArea) return;
     bottomArea.style.cursor = 'pointer';
     bottomArea.title = 'Tap to sync';
-    updateBackupStatus();
     bottomArea.addEventListener('click', async () => {
       if (autoSaveTimer !== null) {
         clearTimeout(autoSaveTimer);

--- a/web/app-state.js
+++ b/web/app-state.js
@@ -62,7 +62,6 @@ const statusDiv = document.getElementById('status-message');
 const deleteSelectedBtn = document.getElementById('delete-selected');
 const exportSelectedBtn = document.getElementById('export-selected');
 const findBtn = document.getElementById('find-btn');
-const backupStatusEl = document.getElementById('last-backup-status');
 const panelLists = document.getElementById('panel-lists');
 const panelArrow = document.getElementById('panel-arrow');
 const panelPin = document.getElementById('panel-pin');
@@ -335,65 +334,23 @@ function _animatePillResize(pillEl, changeFn) {
 // persistent=true: message stays visible until next updateStatus call
 function updateStatus(message, success, persistent = false) {
   const pillEl = document.getElementById('bottom-status-area');
+  // Restore visibility before measuring so _animatePillResize always sees the
+  // pill as live — this lets consecutive messages animate smoothly even if the
+  // previous one had already started fading out.
+  if (pillEl) { pillEl.style.opacity = '1'; pillEl.style.pointerEvents = ''; }
   _animatePillResize(pillEl, () => {
     statusDiv.textContent = toTitleCase(message);
     statusDiv.style.color = success ? 'var(--success)' : 'var(--error)';
     statusDiv.style.opacity = '1';
-    backupStatusEl.style.opacity = '0';
   });
-  // Show pill for the status message
-  if (pillEl) { pillEl.style.opacity = '1'; pillEl.style.pointerEvents = ''; }
   if (statusTimeout) clearTimeout(statusTimeout);
   if (persistent) {
     statusTimeout = null;
   } else {
     statusTimeout = setTimeout(() => {
       statusDiv.style.opacity = '0';
-      if (backupStatusEl.textContent) {
-        backupStatusEl.style.opacity = '1';
-      } else {
-        // No backup status to fall back to — hide the pill
-        if (pillEl) { pillEl.style.opacity = '0'; pillEl.style.pointerEvents = 'none'; }
-      }
+      if (pillEl) { pillEl.style.opacity = '0'; pillEl.style.pointerEvents = 'none'; }
     }, 3000);
-  }
-}
-
-function updateBackupStatus() {
-  const el = document.getElementById('last-backup-status');
-  const pillEl = document.getElementById('bottom-status-area');
-  if (!el) return;
-  const isSynced = !!window.PowerSyncNoteStorage;
-  const isIOS = !!window.Capacitor?.isNativePlatform();
-  const t = localStorage.getItem('last_backup_time');
-  // On iOS, sync is manual — append a tap hint since title tooltips don't show.
-  const suffix = (isSynced && isIOS) ? ' · Tap to Sync' : '';
-  const prefix = isSynced ? 'Synced · ' : '';
-  if (!t) {
-    _animatePillResize(pillEl, () => { el.textContent = ''; });
-    // Hide pill only when no status message is currently showing
-    if (pillEl && statusDiv.style.opacity !== '1') {
-      pillEl.style.opacity = '0';
-      pillEl.style.pointerEvents = 'none';
-    }
-    return;
-  }
-  const diff = Date.now() - parseInt(t, 10);
-  const mins  = Math.floor(diff / 60000);
-  const hours = Math.floor(diff / 3600000);
-  const days  = Math.floor(diff / 86400000);
-  let ago;
-  if (mins < 1)       ago = 'Just Now';
-  else if (mins < 60) ago = `${mins}m Ago`;
-  else if (hours < 24) ago = `${hours}h Ago`;
-  else                 ago = `${days}d Ago`;
-  _animatePillResize(pillEl, () => {
-    el.textContent = `${prefix}Last Backup ${ago}${suffix}`;
-  });
-  // Show pill when there is real backup status to display
-  if (pillEl && statusDiv.style.opacity !== '1') {
-    pillEl.style.opacity = '1';
-    pillEl.style.pointerEvents = '';
   }
 }
 

--- a/web/css/panels.css
+++ b/web/css/panels.css
@@ -207,18 +207,6 @@ body.panel-pinned #panel-open-btn {
   box-shadow: -4px 0 20px var(--shadow-light);
 }
 
-/* ── Last Backed Up status — bottom-center of editor section ── */
-#last-backup-status {
-  grid-row: 1;
-  grid-column: 1;
-  font-size: 11px;
-  color: var(--hr);
-  text-align: center;
-  padding: 1.5px 0;
-  transition: opacity 1s ease;
-}
-
-
 /* ── Panel section headings ── */
 #files-container h2,
 #todo-container h2,

--- a/web/css/responsive.css
+++ b/web/css/responsive.css
@@ -77,28 +77,21 @@ body.panel-pinned {
     display: none !important;
   }
 
-  /* ── Status and backup messages — fixed to bottom of viewport on mobile ── */
+  /* ── Status messages — fixed to bottom of viewport on mobile, pill-shaped ── */
   body:not(.electron) #bottom-status-area {
     position: fixed;
     bottom: 0;
-    left: 0;
-    right: 0;
+    left: 50%;
+    /* transform: translateX(-50%) inherited from toolbar.css — centres the pill */
     z-index: 10;
     background-color: var(--bg);
-    text-align: center;
-    /* Small vertical padding; extra bottom clearance for home indicator */
-    padding: 0.15em 1em max(env(safe-area-inset-bottom), 0.15em);
-    margin: 10px;
+    /* Extra bottom padding clears the home indicator on notched devices */
+    padding: 0.25em 1.2em max(env(safe-area-inset-bottom), 0.25em);
   }
 
   /* Push editor/preview content above the fixed status bar only */
   body:not(.electron) #editor-section {
     padding-bottom: 32px;
-  }
-
-  body:not(.electron) #status-message {
-    z-index: 11;
-    bottom: 4px;
   }
 
   /* ── Swipe navigation: Notes list slides from left ── */

--- a/web/export-import.js
+++ b/web/export-import.js
@@ -473,8 +473,6 @@ async function downloadAllNotes() {
     return;
   }
 
-  localStorage.setItem('last_backup_time', Date.now().toString());
-  updateBackupStatus();
   updateStatus(`Backed Up ${allNotes.length} Note${allNotes.length === 1 ? '' : 's'}.`, true);
 }
 
@@ -498,8 +496,6 @@ async function backupSelectedNotes() {
     return;
   }
 
-  localStorage.setItem('last_backup_time', Date.now().toString());
-  updateBackupStatus();
   updateStatus(`Backed Up ${notes.length} Note${notes.length === 1 ? '' : 's'}.`, true);
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -398,7 +398,6 @@
         <div id="preview" style="display:none;"></div>
         <div id="bottom-status-area">
           <div id="status-message"></div>
-          <div id="last-backup-status"></div>
         </div>
       </div>
 


### PR DESCRIPTION
- Remove #last-backup-status element, its CSS, updateBackupStatus() function,
  and all call sites (app-init.js, export-import.js) — the pill no longer
  shows a persistent "Last Backup Xm Ago" timestamp on any platform.
- Fix mobile pill width bug: the responsive.css override previously set
  left:0; right:0; margin:10px forcing the pill to full viewport width.
  Replaced with left:50% so the inherited transform:translateX(-50%) centres
  the pill and it naturally hugs its text content.
- Fix consecutive-message transitions: moved pillEl.style.opacity='1' to
  before _animatePillResize() in updateStatus() so a new message that arrives
  while the previous one is mid-fade-out restores visibility first, allowing
  _animatePillResize to measure and animate the width change smoothly instead
  of skipping straight to the new size.

https://claude.ai/code/session_012DZrh3ZDAtBSsd7KoZbQCw