### PR TITLE
Add warnings for notes encrypted with different keys

### DIFF
--- a/web/app-init.js
+++ b/web/app-init.js
@@ -1474,6 +1474,25 @@ async function migrateLocalNotesToSync() {
       delete window._encryption._checkForEncryptedContent;
     }
 
+    // ── E2E Encryption: warn when specific notes can't be decrypted ──────────
+    // Encryption is active but some notes returned ciphertext — they were
+    // encrypted with a different key (older key, or a device that was never
+    // paired with this one). The notes are not lost, but unreadable until the
+    // correct key is restored from a backup or via device pairing.
+    if (window._encryption.active && window._encryption.undecryptableNotes?.size > 0) {
+      const count = window._encryption.undecryptableNotes.size;
+      console.warn(
+        '[encryption]', count, 'note(s) could not be decrypted with the current key:',
+        [...window._encryption.undecryptableNotes]
+      );
+      updateStatus(
+        count + ' note' + (count !== 1 ? 's' : '') +
+        ' could not be decrypted \u2014 they may have been encrypted with a different key. ' +
+        'Restore a key backup in Settings \u2192 Encryption to recover them.',
+        false
+      );
+    }
+
     // If this device needs an encryption key, show a persistent warning and
     // make notes read-only to prevent saving ciphertext as plaintext.
     if (window._encryption.needsKey && !window._encryption.active) {

--- a/web/crypto-storage.js
+++ b/web/crypto-storage.js
@@ -92,6 +92,7 @@ window.CryptoStorage = {
     wrapped.getAllNotes = async function () {
       const notes = await storage.getAllNotes();
       const results = [];
+      const failed = [];
       for (const n of notes) {
         if (_SPECIAL_NOTES.has(n.name) || !CryptoEngine.isEncrypted(n.content)) {
           results.push(n);
@@ -101,9 +102,16 @@ window.CryptoStorage = {
             results.push({ name: n.name, content: plaintext });
           } catch (e) {
             console.error('[crypto-storage] Decrypt failed for note:', n.name, e);
+            failed.push(n.name);
             results.push(n); // pass through ciphertext
           }
         }
+      }
+      // Expose the set of undecryptable note names so the UI can warn the user.
+      // These notes are encrypted with a key this device doesn't hold (e.g. from
+      // a previous key or a device that was never paired with this one).
+      if (window._encryption) {
+        window._encryption.undecryptableNotes = failed.length > 0 ? new Set(failed) : null;
       }
       return results;
     };

--- a/web/markdown-renderer.js
+++ b/web/markdown-renderer.js
@@ -1644,6 +1644,30 @@ function injectEncryptionSettings(container) {
 
       // Use the unwrapped storage for migration (write ciphertext directly)
       const storage = window.NoteStorage._unwrapped || window.NoteStorage;
+
+      // Warn if some notes are already encrypted with a different key.
+      // migrateToEncrypted() skips notes that already start with 'enc:v1:', so any
+      // notes synced from another device (or a previous encryption session) will
+      // remain encrypted with the old key and be unreadable on this device.
+      const allNotesRaw = await storage.getAllNotes();
+      const alreadyEncrypted = allNotesRaw.filter(
+        n => n.content && CryptoEngine.isEncrypted(n.content)
+      );
+      if (alreadyEncrypted.length > 0) {
+        console.warn(
+          '[encryption] ' + alreadyEncrypted.length +
+          ' note(s) are already encrypted with a different key and will remain unreadable:',
+          alreadyEncrypted.map(n => n.name)
+        );
+        const foreignKeyWarn = document.createElement('p');
+        foreignKeyWarn.className = 'encryption-warning';
+        foreignKeyWarn.textContent =
+          alreadyEncrypted.length + ' note' + (alreadyEncrypted.length !== 1 ? 's' : '') +
+          ' are already encrypted with a different key and cannot be read on this device. ' +
+          'Pair with the device that holds the original key, or restore a key backup, to recover them.';
+        wrap.appendChild(foreignKeyWarn);
+      }
+
       const count = await CryptoStorage.migrateToEncrypted(storage, masterKey, (done, total) => {
         progressEl.textContent = `Encrypting notes\u2026 ${done}/${total}`;
       });


### PR DESCRIPTION
## Summary
This PR adds user-facing warnings when notes are encrypted with a different encryption key than the one currently active on the device. This helps users understand why certain notes appear as unreadable ciphertext and guides them toward recovery options.

## Key Changes

- **crypto-storage.js**: Modified `getAllNotes()` to track notes that fail decryption and expose them via `window._encryption.undecryptableNotes`. Failed decryptions are logged and the ciphertext is passed through so the UI can detect them.

- **app-init.js**: Added a check during migration to detect undecryptable notes and display a status message guiding users to restore a key backup or use device pairing to recover them.

- **markdown-renderer.js**: Added pre-migration validation in the encryption settings UI that warns users if notes are already encrypted with a different key before attempting migration. Displays both a console warning and an in-UI warning message.

## Implementation Details

- Notes that fail decryption are identified by catching exceptions during the decryption process in `getAllNotes()`
- The set of undecryptable note names is stored in `window._encryption.undecryptableNotes` for UI consumption
- Warnings are shown at two points: during initial sync/load (app-init.js) and during encryption setup (markdown-renderer.js)
- User guidance directs them to either restore a key backup or pair with the device that holds the original key
- The implementation gracefully handles the case where notes remain encrypted but unreadable, preventing data loss while making the situation transparent to the user

https://claude.ai/code/session_01VTbb5T88BvUR1DJWw6LUQH