### PR TITLE
Move native traffic lights off-screen on macOS

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -290,11 +290,11 @@ function createWindow(secondary = false) {
     title: 'Notes App',
     backgroundColor: '#1e1e1e',
     show: false,
-    // macOS: hide the entire native title bar (including traffic lights).
-    // Custom HTML traffic-light buttons are rendered inside #button-container
-    // so they float inside the toolbar pill.  IPC handlers below handle the
+    // macOS: hide the native title bar and move the native traffic lights
+    // off-screen so only the custom HTML traffic-light buttons inside
+    // #button-container are visible.  IPC handlers below handle the
     // close / minimise / maximise actions from those buttons.
-    ...(isMac ? { titleBarStyle: 'hidden' } : {}),
+    ...(isMac ? { titleBarStyle: 'hidden', trafficLightPosition: { x: -100, y: 0 } } : {}),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       nodeIntegration: false,

--- a/web/css/base.css
+++ b/web/css/base.css
@@ -80,15 +80,13 @@ body {
                           z-index 98, behind the toolbar (100). Handles empty
                           space on the right side of the toolbar not covered by
                           #button-container content.
-   #button-container    — anchored to the left edge so the native traffic-light
-                          buttons (rendered by Electron at x=10) visually sit
-                          inside the pill.  padding-left reserves space for the
-                          three 12 px circles + gaps (~68 px from x=10) plus a
-                          small margin.  Also marked draggable so empty gaps
-                          between buttons initiate a native drag; interactive
-                          children opt-out below.
-
-   Tune trafficLightPosition in main.js and padding-left here together.
+   #button-container    — anchored to the left edge so the custom HTML
+                          traffic-light buttons (#traffic-lights) sit at the
+                          start of the pill.  Native Electron traffic lights are
+                          moved off-screen via trafficLightPosition in main.js.
+                          Also marked draggable so empty gaps between buttons
+                          initiate a native drag; interactive children opt-out
+                          below.
 */
 body.platform-darwin #window-drag-region {
   position: fixed;

--- a/web/css/responsive.css
+++ b/web/css/responsive.css
@@ -10,8 +10,8 @@ body.panel-pinned {
    left:var(--gap) aligns the pill's left edge with the note content left edge
    (content also has padding-left:var(--gap)). */
 @media (min-width: 651px) {
-  /* Left-align for all desktop platforms (macOS padding-left already in the
-     platform-darwin rule above; traffic lights appear inside the pill there). */
+  /* Left-align for all desktop platforms (macOS anchors the pill to the left
+     edge so the custom HTML traffic lights appear at the start of the pill). */
   #button-container {
     left: 5px;
     transform: none;


### PR DESCRIPTION
## Summary
This PR refactors how traffic light buttons are handled on macOS by moving the native Electron traffic lights off-screen and relying solely on custom HTML traffic light buttons rendered in the toolbar.

## Key Changes
- **main.js**: Added `trafficLightPosition: { x: -100, y: 0 }` to the BrowserWindow options on macOS to move native traffic lights off-screen instead of hiding the entire title bar and positioning custom buttons to overlap them
- **base.css**: Updated comments to reflect that custom HTML traffic-light buttons (#traffic-lights) now sit at the start of the pill, with native lights moved off-screen rather than hidden
- **responsive.css**: Clarified that the pill is anchored to the left edge on macOS so custom HTML traffic lights appear at the start

## Implementation Details
- The native Electron traffic lights are now positioned at x: -100 (off-screen) rather than being hidden, allowing the custom HTML buttons to be the only visible traffic light controls
- The `#button-container` no longer needs special padding calculations to accommodate native traffic lights
- This approach provides better control over the appearance and behavior of traffic light buttons while maintaining native functionality through IPC handlers

https://claude.ai/code/session_01Lb7qLa8DygzgzauhCFp37t