### PR TITLE
Fix mobile panel positioning and safe area handling

### DIFF
--- a/web/css/responsive.css
+++ b/web/css/responsive.css
@@ -95,35 +95,37 @@ body.panel-pinned {
   }
 
   /* ── Swipe navigation: Notes list slides from left ── */
-  /* Gap is anchored to the physical screen edge (ignores safe areas) so the
-     panel floats with an even margin.  Internal padding-top compensates for
-     the notch so content inside the panel is not obscured. */
+  /* Panel is attached flush to the left screen edge (margin: 0, left: 0).
+     padding-top compensates for the notch; padding-left uses only the physical
+     safe-area inset so content is not obscured in landscape orientation. */
   body:not(.electron) #panel-lists {
     position: fixed;
     right: auto;
-    width: calc(80vw - var(--gap) * 2);
+    width: 80vw;
     max-width: 300px;
     height: 100%;
-    transform: translateX(calc(-100% - var(--gap) * 3));
+    margin: 0;
+    transform: translateX(-100%);
     transition: transform 0.25s ease, box-shadow 0.25s ease;
     display: flex !important;
     visibility: visible;
     pointer-events: auto;
     flex-direction: column;
     border: none;
-    border-radius: 20px;
+    border-radius: 0 20px 20px 0;
     z-index: 150;
     will-change: transform;
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;
     box-shadow: none;
     padding-top: calc(env(safe-area-inset-top) + var(--gap));
-    padding-left: calc(var(--gap) * 2);
+    padding-right: var(--gap);
+    padding-left: env(safe-area-inset-left);
   }
 
   body:not(.electron) #panel-lists.visible,
   body:not(.electron) #panel-lists.pinned {
-    transform: translateX(calc(-100% - var(--gap) * 3));
+    transform: translateX(-100%);
   }
 
   body:not(.electron) #panel-lists.mobile-open-left,
@@ -133,23 +135,30 @@ body.panel-pinned {
     box-shadow: 0 1px 4px var(--shadow), 0 6px 20px var(--shadow-light);
   }
 
+  body:not(.electron) #nav-list {
+    padding-bottom: max(env(safe-area-inset-bottom), var(--gap));
+  }
+
   /* ── Right panel (tasks/schedule) slides from right ── */
   #mobile-right-panel {
     position: fixed;
-    top: var(--gap);
-    right: var(--gap);
-    width: calc(80vw - var(--gap) * 2);
+    top: 0;
+    right: 0;
+    width: 80vw;
     max-width: 300px;
-    height: calc(100% - var(--gap) * 2);
-    transform: translateX(calc(100% + var(--gap) * 3));
+    height: 100%;
+    transform: translateX(100%);
     transition: transform 0.25s ease, box-shadow 0.25s ease;
     display: flex;
     flex-direction: column;
     background-color: var(--bg);
     border: none;
-    border-radius: 20px;
+    border-radius: 20px 0 0 20px;
     z-index: 150;
-    padding: calc(env(safe-area-inset-top) + var(--gap)) calc(var(--gap) * 2) var(--gap);
+    padding-top: calc(env(safe-area-inset-top) + var(--gap));
+    padding-right: env(safe-area-inset-right);
+    padding-bottom: max(env(safe-area-inset-bottom), var(--gap));
+    padding-left: var(--gap);
     box-sizing: border-box;
     overflow: hidden;
     will-change: transform;


### PR DESCRIPTION
## Summary
Refactored the mobile panel layout system to properly handle safe areas (notches, home indicators) and improve edge-to-edge panel positioning on mobile devices.

## Key Changes
- **Left panel (#panel-lists)**: Changed from gap-based positioning to flush left edge alignment
  - Removed gap-based width calculation (`80vw - var(--gap) * 2` → `80vw`)
  - Simplified transform from `translateX(calc(-100% - var(--gap) * 3))` to `translateX(-100%)`
  - Updated border-radius to `0 20px 20px 0` (rounded right side only)
  - Changed padding: uses `env(safe-area-inset-left)` for left padding instead of gap-based calculation
  - Added `padding-right: var(--gap)` for internal spacing

- **Right panel (#mobile-right-panel)**: Changed from gap-inset positioning to flush right edge alignment
  - Removed gap offsets from top/right positioning (`top: var(--gap)` → `top: 0`, `right: var(--gap)` → `right: 0`)
  - Simplified width calculation (`80vw - var(--gap) * 2` → `80vw`)
  - Changed height from `calc(100% - var(--gap) * 2)` to `100%`
  - Simplified transform from `translateX(calc(100% + var(--gap) * 3))` to `translateX(100%)`
  - Updated border-radius to `20px 0 0 20px` (rounded left side only)
  - Refactored padding to use safe area insets: `env(safe-area-inset-top)`, `env(safe-area-inset-right)`, and `max(env(safe-area-inset-bottom), var(--gap))`

- **Navigation list (#nav-list)**: Added bottom padding to respect safe area insets

## Implementation Details
The changes ensure that:
- Panels extend edge-to-edge on mobile devices for a modern full-screen appearance
- Safe area insets (notches, home indicators) are properly respected so content isn't obscured
- Gap spacing is used for internal content padding rather than external positioning
- Both panels have appropriate border-radius on the inner edges only

https://claude.ai/code/session_01VF98eSYFba62gW2hLVawDe