### PR TITLE
Refactor file list indicators to use consistent left gutter system

### DIFF
--- a/web/css/file-list.css
+++ b/web/css/file-list.css
@@ -32,7 +32,7 @@
 #fileList {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 3px; /* 3px left gutter for indicator lines */
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -62,26 +62,17 @@
   background-color: var(--today-bg);
 }
 
-/* ── Active note: straight accent border on the left, background on hover only ── */
-/* Uses border-left with zero left-side border-radius so the border is perfectly
-   straight — the ::before approach was rounded by overflow:hidden + border-radius. */
-#fileList li.active-file,
-#nav-list li.active-file {
-  font-weight: bold;
-  color: var(--active-color);
-  border-left: 3px solid var(--accent);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  padding-left: 2px; /* 5px normal - 3px border = same text position */
-}
-
 /* ── Link chain: connected thread with fading trail ── */
+/* Dashed left border; zero left-radius keeps the dashes perfectly straight.
+   Negative margin pulls the border into the list's 3 px left gutter. */
 #fileList li.linked-file,
 #nav-list li.linked-file {
   color: var(--linked-color);
   border-left: 2px dashed var(--linked-border);
-  padding-left: 6px;
-  margin-left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -3px;
+  padding-left: 6px; /* 3px gutter - 3px margin + 2px border + 6px pad = 8px text from panel */
 }
 
 /* Step number badge on each linked note */
@@ -98,13 +89,19 @@
 #nav-list {
   list-style: none;
   margin: 0;
-  padding: 10px 0;
+  padding: 10px 0 10px 3px; /* top/bottom unchanged; 3px left gutter matches #fileList */
   flex-shrink: 0;
 }
 
-/* ── Today's Daily Note highlight ── */
+/* ── Today's Daily Note ── */
+/* Solid border-only indicator — background is reserved for the active note.
+   Zero left-radius and gutter margin keep the line straight. */
 #fileList li.today-note {
-  background-color: var(--today-bg);
+  border-left: 2px solid var(--accent);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -3px;
+  padding-left: 6px; /* aligns text with normal items at 8px from panel left */
 }
 
 #fileList li.today-note > span {
@@ -119,19 +116,34 @@
 }
 
 /* ── Second note: currently open note shown just below today's note ── */
-/* Indicated only by the straight accent border — no persistent background so
-   the background stays consistent with the note's non-active appearance and
-   only changes on hover (via the shared :hover rule). */
+/* Solid border indicator — no persistent background. */
 #fileList li.second-note {
-  border-left: 3px solid var(--accent);
+  border-left: 2px solid var(--accent);
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  padding-left: 2px; /* keep text at same indent as normal items */
+  margin-left: -3px;
+  padding-left: 6px;
 }
 
 #fileList li.second-note > span {
   color: var(--today-color);
   font-weight: bold;
+}
+
+/* ── Active note: accent border + background highlight ── */
+/* Defined last so it wins the CSS cascade when combined with .today-note,
+   .second-note, or .linked-file. Wider 3 px border and persistent background
+   clearly distinguish it from the other border-only indicators. */
+#fileList li.active-file,
+#nav-list li.active-file {
+  background-color: var(--today-bg);
+  font-weight: bold;
+  color: var(--active-color);
+  border-left: 3px solid var(--accent);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -3px;
+  padding-left: 5px; /* 3px gutter - 3px margin + 3px border + 5px pad = 8px text from panel */
 }
 
 /* ── Copy float feedback ────────────────────────────────────────────────── */
@@ -149,4 +161,3 @@
   position: relative;
   z-index: 1;
 }
-


### PR DESCRIPTION
## Summary
Redesigned the file list indicator system to use a unified 3px left gutter approach, replacing inconsistent padding and border strategies with a cleaner, more maintainable layout system.

## Key Changes
- **Added 3px left gutter** to `#fileList` and `#nav-list` padding to create a consistent space for indicator lines
- **Standardized indicator styling** across all note states (linked, today, second, active) using negative margins to pull borders into the gutter
- **Unified border widths and styling**:
  - Linked notes: 2px dashed border
  - Today's note: 2px solid border (new indicator style)
  - Second note: 2px solid border (reduced from 3px)
  - Active note: 3px solid border with background (maintains visual hierarchy)
- **Removed background color** from today's note in favor of a border-only indicator, reserving background styling for the active note
- **Reordered CSS rules** to place active note styles last, ensuring they take precedence in the cascade when combined with other indicator classes
- **Updated padding calculations** across all indicator styles to maintain consistent 8px text offset from the panel left edge

## Implementation Details
- All indicator borders use `border-top-left-radius: 0` and `border-bottom-left-radius: 0` to keep lines perfectly straight
- Negative `margin-left: -3px` pulls borders into the gutter space, eliminating the need for complex padding adjustments
- Padding values adjusted to account for the gutter margin and border width: `padding-left = 8px - gutter(3px) + margin(-3px) - border(width)`
- Active note styling defined last in cascade to override other indicator classes when multiple are present

https://claude.ai/code/session_018xY4mHFDogd8C5T2vZQAXX