### PR TITLE
Improve mobile UI responsiveness and panel styling

### DIFF
--- a/web/css/panels.css
+++ b/web/css/panels.css
@@ -37,6 +37,13 @@
   white-space: nowrap;
 }
 
+@media (hover: hover) {
+  #todo-container .todo-note-title:hover {
+    color: var(--panel-heading-hover);
+    cursor: pointer;
+  }
+}
+
 #todoList > li {
   margin-bottom: 20px;
 }

--- a/web/css/responsive.css
+++ b/web/css/responsive.css
@@ -77,6 +77,12 @@ body.panel-pinned {
     display: none !important;
   }
 
+  /* Notes h2 does nothing on mobile (no panel to cycle to) — remove the
+     pointer cursor so it doesn't mislead the user into tapping it. */
+  body:not(.electron) #files-container h2 {
+    cursor: default;
+  }
+
   /* ── Status messages — fixed to bottom of viewport on mobile, pill-shaped ── */
   body:not(.electron) #bottom-status-area {
     position: fixed;
@@ -156,7 +162,7 @@ body.panel-pinned {
     border-radius: 20px 0 0 20px;
     z-index: 150;
     padding-top: calc(env(safe-area-inset-top) + var(--gap));
-    padding-right: env(safe-area-inset-right);
+    padding-right: max(env(safe-area-inset-right), var(--gap));
     padding-bottom: max(env(safe-area-inset-bottom), var(--gap));
     padding-left: var(--gap);
     box-sizing: border-box;
@@ -170,6 +176,14 @@ body.panel-pinned {
   #mobile-right-panel.mobile-open-right {
     transform: translateX(0);
     box-shadow: 0 1px 4px var(--shadow), 0 6px 20px var(--shadow-light);
+  }
+
+  /* The shared container rule (outside the media query) gives every panel
+     padding-left: 10px. Inside #mobile-right-panel that would double up with
+     the panel's own padding-left: var(--gap). Reset it here. */
+  body:not(.electron) #todo-container,
+  body:not(.electron) #schedule-container {
+    padding-left: 0;
   }
 
   /* Overlay backdrop when a panel is open */

--- a/web/css/theme.css
+++ b/web/css/theme.css
@@ -141,11 +141,11 @@ input[type="checkbox"] {
   align-self: flex-start;
 }
 
-/* Schedule: 1em square, slightly less rounded (matches item row style) */
+/* Schedule: 1em square, same rounding as preview/todo checkboxes */
 #schedule-container .schedule-item input[type="checkbox"] {
   width: 1em;
   height: 1em;
-  border-radius: 2px;
+  border-radius: 0.2em;
 }
 
 /* Search panel: slightly smaller to sit inline with the compact search row */


### PR DESCRIPTION
This PR makes several refinements to the mobile and responsive design of the application, focusing on cursor behavior, padding consistency, and visual styling.

**Key changes:**

- **Mobile cursor behavior**: Remove pointer cursor from Notes h2 heading on mobile since tapping it doesn't cycle panels (non-Electron only), preventing misleading UX
- **Panel padding consistency**: Fix double-padding issue in mobile right panel by resetting `padding-left` on todo and schedule containers, which inherit padding from a shared container rule
- **Safe area inset handling**: Update right padding in mobile right panel to use `max()` function, ensuring minimum gap spacing even when safe area inset is zero
- **Hover state styling**: Add hover color and pointer cursor for todo note titles only on devices that support hover, improving desktop interactivity without affecting touch devices
- **Checkbox styling**: Standardize schedule item checkbox border-radius to `0.2em` to match preview and todo checkboxes instead of using a fixed `2px` value

These changes improve the mobile experience by preventing misleading interactions, fixing layout issues with padding, and ensuring consistent visual styling across different panel types.

https://claude.ai/code/session_0161jjL1hXoRYztBr5JNXhtn