### PR TITLE
Add drag-to-move and drag-to-resize for schedule items

### DIFF
--- a/web/css/schedule.css
+++ b/web/css/schedule.css
@@ -301,3 +301,104 @@
 .dot-overdue     { background-color: var(--error); }
 .dot-today       { background-color: var(--warning); }
 .dot-future      { background-color: var(--success); }
+
+/* ── Schedule drag-to-move and drag-to-resize ────────────────────────────── */
+
+/* Grab cursor on the block body (hover-capable devices only) */
+@media (hover: hover) {
+  .schedule-item { cursor: grab; }
+  .schedule-item input[type="checkbox"] { cursor: default; }
+  .schedule-event-icon { cursor: grab; }
+}
+
+/* Dim the original block while it is being moved */
+.schedule-item-drag-source {
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+/* Global grabbing cursor + no text selection while any drag is active */
+body.schedule-dragging,
+body.schedule-dragging * {
+  cursor: grabbing !important;
+  user-select: none !important;
+  -webkit-user-select: none !important;
+}
+
+/* Floating clone that follows the cursor during drag-to-move */
+.schedule-drag-clone {
+  position: fixed;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.85;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.35);
+  border-radius: 0 5px 5px 0;
+  border-left: 3px solid var(--sched-item-border);
+  background: var(--sched-item-bg);
+  font-size: 12px;
+  overflow: hidden;
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.35em;
+  padding: 2px 6px;
+}
+
+/* Drop target outline — shows where the item will land */
+.schedule-drop-outline {
+  position: absolute;
+  left: 40px;
+  right: 0;
+  margin: 0 10px 0 5px;
+  border: 2px dashed var(--sched-item-border);
+  border-radius: 0 5px 5px 0;
+  background: var(--sched-item-bg);
+  opacity: 0.5;
+  pointer-events: none;
+  box-sizing: border-box;
+  z-index: 5;
+  display: none;
+}
+
+/* Resize handle: invisible 8px strip at the bottom of each timed block */
+.schedule-resize-handle {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 8px;
+  cursor: ns-resize;
+  border-radius: 0 0 5px 0;
+  touch-action: none;
+}
+
+/* Subtle grip indicator shown on hover */
+.schedule-resize-handle::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 3px;
+  transform: translateX(-50%);
+  width: 24px;
+  height: 2px;
+  border-radius: 1px;
+  background: currentColor;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+@media (hover: hover) {
+  .schedule-item:hover .schedule-resize-handle::after { opacity: 0.3; }
+}
+
+/* Hide resize handle inside the all-day section (those items are not resizable) */
+.schedule-allday-section .schedule-resize-handle { display: none; }
+
+/* Larger hit area on touch devices */
+@media (any-pointer: coarse) {
+  .schedule-resize-handle { height: 14px; }
+}
+
+/* Prevent scroll-hijacking on draggable items (touch) */
+.schedule-item { touch-action: pan-y; }
+.schedule-allday-section .schedule-item { touch-action: pan-y; }

--- a/web/index.html
+++ b/web/index.html
@@ -484,6 +484,7 @@
   <script defer src="app-state.js"></script>
   <script defer src="markdown-renderer.js"></script>
   <script defer src="schedule.js"></script>
+  <script defer src="schedule-drag.js"></script>
   <script defer src="file-list.js"></script>
   <script defer src="note-manager.js"></script>
   <script defer src="export-import.js"></script>

--- a/web/schedule-drag.js
+++ b/web/schedule-drag.js
@@ -1,0 +1,406 @@
+// schedule-drag.js — Drag-to-move and drag-to-resize for the schedule view.
+//
+// Provides two interactions on timed and all-day schedule blocks:
+//   1. Drag-to-move: mousedown/touchstart on the block body lifts the item
+//      so it can be dropped at a new time (or onto the timed grid for all-day items).
+//   2. Drag-to-resize: mousedown/touchstart on the 8px resize handle at the
+//      bottom of each timed block changes the end time in 15-min increments.
+//
+// Depends on globals from:
+//   app-state.js  — NoteStorage, currentFileName, textarea, isPreview,
+//                   projectsViewActive, scheduleDate, scheduleGrid
+//   schedule.js   — invalidateScheduleCache, renderSchedule
+//   note-manager.js / markdown-renderer.js — renderPreview, refreshHighlight
+
+// ── Constants ──────────────────────────────────────────────────────────────
+const _SD_ROW_H         = 40;   // px per 30-min slot — must match schedule.js
+const _SD_SNAP          = 15;   // snap granularity in minutes
+const _SD_MIN_DUR       = 15;   // minimum event duration (minutes)
+const _SD_ALLDAY_DUR    = 30;   // default duration (min) for all-day → timed drops
+const _SD_DRAG_THRESH   = 4;    // px movement before mousedown becomes a drag
+const _SD_SCROLL_ZONE   = 60;   // px from wrapper edge to trigger auto-scroll
+const _SD_SCROLL_SPEED  = 6;    // max px per RAF frame for auto-scroll
+
+// ── Module state ───────────────────────────────────────────────────────────
+let _sd_drag   = null;   // active drag descriptor, or null when idle
+let _sd_clone  = null;   // floating DOM clone during drag-to-move
+let _sd_outline = null;  // drop-target outline element inside scheduleGrid
+let _sd_rafId  = null;   // requestAnimationFrame id for auto-scroll
+let _sd_lastClientY = 0; // updated each pointermove for the RAF loop
+
+// ── Time utilities ─────────────────────────────────────────────────────────
+
+function _sdMinsToHHMM(totalMins) {
+  totalMins = Math.max(0, Math.min(Math.round(totalMins), 23 * 60 + 59));
+  const h = Math.floor(totalMins / 60);
+  const m = totalMins % 60;
+  return String(h).padStart(2, '0') + String(m).padStart(2, '0');
+}
+
+function _sdHHMMtoMins(hhmm) {
+  return parseInt(hhmm.slice(0, 2), 10) * 60 + parseInt(hhmm.slice(2), 10);
+}
+
+function _sdSnap(mins) {
+  return Math.round(mins / _SD_SNAP) * _SD_SNAP;
+}
+
+function _sdPxToMins(px) {
+  return (px / _SD_ROW_H) * 30;
+}
+
+function _sdMinsToTopPx(mins) {
+  return (mins / 30) * _SD_ROW_H;
+}
+
+// Returns the minutes-from-midnight value for a given viewport clientY,
+// accounting for the grid's scroll offset inside the timeline wrapper.
+function _sdClientYToGridMins(clientY) {
+  const grid = document.getElementById('scheduleGrid');
+  if (!grid) return 0;
+  const wrapper = document.getElementById('schedule-timeline-wrapper');
+  const gridRect = grid.getBoundingClientRect();
+  // clientY relative to grid top, plus current scroll so result is in "grid space"
+  const relY = clientY - gridRect.top + (wrapper ? wrapper.scrollTop : 0);
+  return _sdPxToMins(relY);
+}
+
+// Extract {clientX, clientY} from either a MouseEvent or a TouchEvent.
+function _sdClient(e) {
+  if (e.touches && e.touches.length) {
+    return { clientX: e.touches[0].clientX, clientY: e.touches[0].clientY };
+  }
+  if (e.changedTouches && e.changedTouches.length) {
+    return { clientX: e.changedTouches[0].clientX, clientY: e.changedTouches[0].clientY };
+  }
+  return { clientX: e.clientX, clientY: e.clientY };
+}
+
+// ── Markdown write-back ────────────────────────────────────────────────────
+
+// Replaces the HHMM HHMM portion of a timed schedule line, preserving
+// everything else (task prefix, date, @calendar-tag).
+// Returns the updated line string, or null if the line doesn't match.
+function _sdReplaceTimedLine(line, newStart, newEnd) {
+  const re = /(>\s*\d{6}\s+)\d{4}(\s+)\d{4}/;
+  if (!re.test(line)) return null;
+  return line.replace(re, (_, pre, sep) => `${pre}${newStart}${sep}${newEnd}`);
+}
+
+// Converts an all-day line (> YYMMDD) to a timed line (> YYMMDD HHMM HHMM).
+// Preserves prefix and optional @tag(s).
+// Returns the updated line, or null if the pattern isn't found.
+// Must only be called on lines that do NOT already have HHMM tokens (i.e. isAllDay items).
+function _sdAlldayToTimedLine(line, newStart, newEnd) {
+  const re = /(>\s*\d{6})((?:\s+@\S+)*)\s*$/;
+  if (!re.test(line)) return null;
+  return line.replace(re, (_, datepart, tags) => `${datepart} ${newStart} ${newEnd}${tags}`);
+}
+
+// Commits a time change to the markdown source file and refreshes the view.
+async function _sdCommit(item, newStart, newEnd) {
+  const content = await NoteStorage.getNote(item.fileName);
+  if (!content) return;
+  const lines = content.split('\n');
+  if (item.lineIndex < 0 || item.lineIndex >= lines.length) return;
+
+  let updated;
+  if (item.isAllDay) {
+    updated = _sdAlldayToTimedLine(lines[item.lineIndex], newStart, newEnd);
+  } else {
+    updated = _sdReplaceTimedLine(lines[item.lineIndex], newStart, newEnd);
+  }
+  if (!updated || updated === lines[item.lineIndex]) return;
+
+  lines[item.lineIndex] = updated;
+  const newContent = lines.join('\n');
+  await NoteStorage.setNote(item.fileName, newContent);
+
+  if (currentFileName === item.fileName) {
+    textarea.value = newContent;
+    if (isPreview || projectsViewActive) {
+      if (typeof renderPreview === 'function') renderPreview();
+    } else {
+      if (typeof refreshHighlight === 'function') refreshHighlight();
+    }
+  }
+
+  invalidateScheduleCache();
+  await renderSchedule();
+}
+
+// ── Drop outline ───────────────────────────────────────────────────────────
+
+function _sdShowOutline(startMins, durationMins) {
+  const grid = document.getElementById('scheduleGrid');
+  if (!grid) return;
+  if (!_sd_outline) {
+    _sd_outline = document.createElement('div');
+    _sd_outline.className = 'schedule-drop-outline';
+    grid.appendChild(_sd_outline);
+  }
+  const topPx    = _sdMinsToTopPx(startMins) + 2;
+  const heightPx = Math.max(_sdMinsToTopPx(durationMins) - 4, _SD_ROW_H / 2 - 4);
+  _sd_outline.style.top     = topPx + 'px';
+  _sd_outline.style.height  = heightPx + 'px';
+  _sd_outline.style.display = 'block';
+}
+
+function _sdHideOutline() {
+  if (_sd_outline) {
+    _sd_outline.style.display = 'none';
+  }
+}
+
+function _sdRemoveOutline() {
+  if (_sd_outline) {
+    _sd_outline.remove();
+    _sd_outline = null;
+  }
+}
+
+// ── Auto-scroll RAF loop ───────────────────────────────────────────────────
+
+function _sdStartScrollLoop() {
+  if (_sd_rafId) return;
+  function tick() {
+    _sd_rafId = null;
+    if (!_sd_drag) return;
+    const wrapper = document.getElementById('schedule-timeline-wrapper');
+    if (!wrapper) return;
+    const rect     = wrapper.getBoundingClientRect();
+    const relY     = _sd_lastClientY - rect.top;
+    const fromTop  = relY;
+    const fromBot  = rect.height - relY;
+    let delta = 0;
+    if (fromTop < _SD_SCROLL_ZONE && fromTop > 0) {
+      delta = -_SD_SCROLL_SPEED * (1 - fromTop / _SD_SCROLL_ZONE);
+    } else if (fromBot < _SD_SCROLL_ZONE && fromBot > 0) {
+      delta = _SD_SCROLL_SPEED * (1 - fromBot / _SD_SCROLL_ZONE);
+    }
+    if (delta !== 0) {
+      wrapper.scrollTop = Math.max(0, wrapper.scrollTop + delta);
+    }
+    _sd_rafId = requestAnimationFrame(tick);
+  }
+  _sd_rafId = requestAnimationFrame(tick);
+}
+
+function _sdStopScrollLoop() {
+  if (_sd_rafId) { cancelAnimationFrame(_sd_rafId); _sd_rafId = null; }
+}
+
+// ── Drag-to-move helpers ───────────────────────────────────────────────────
+
+// Computes snapped start/end minutes from current clientY, clamping to day.
+function _sdCalcMove(clientY) {
+  const d = _sd_drag;
+  const rawMins   = _sdClientYToGridMins(clientY) - d.offsetMins;
+  const snapped   = _sdSnap(rawMins);
+  const startMins = Math.max(0, Math.min(snapped, 24 * 60 - d.durationMins));
+  const endMins   = Math.min(startMins + d.durationMins, 23 * 60 + 59);
+  return { startMins, endMins };
+}
+
+// True when clientY is within the scrollable timed grid wrapper.
+function _sdInTimedArea(clientY) {
+  const wrapper = document.getElementById('schedule-timeline-wrapper');
+  if (!wrapper) return false;
+  const r = wrapper.getBoundingClientRect();
+  return clientY >= r.top && clientY <= r.bottom;
+}
+
+// ── Drag-to-resize helpers ─────────────────────────────────────────────────
+
+function _sdCalcResize(clientY) {
+  const d       = _sd_drag;
+  const rawMins = _sdClientYToGridMins(clientY);
+  const snapped = _sdSnap(rawMins);
+  const endMins = Math.max(d.startMins + _SD_MIN_DUR, Math.min(snapped, 23 * 60 + 59));
+  return endMins;
+}
+
+// ── Shared cleanup ─────────────────────────────────────────────────────────
+
+function _sdCleanup(block) {
+  _sdStopScrollLoop();
+  _sdRemoveOutline();
+  document.body.classList.remove('schedule-dragging');
+  if (_sd_clone) { _sd_clone.remove(); _sd_clone = null; }
+  if (block)     { block.classList.remove('schedule-item-drag-source'); }
+}
+
+// ── Global pointer-move handler ────────────────────────────────────────────
+
+function _sdOnMove(e) {
+  if (!_sd_drag) return;
+  const { clientX, clientY } = _sdClient(e);
+  _sd_lastClientY = clientY;
+
+  // Upgrade 'pending' → active once threshold is crossed
+  if (!_sd_drag.active) {
+    const dx = Math.abs(clientX - _sd_drag.startX);
+    const dy = Math.abs(clientY - _sd_drag.startY);
+    if (dx < _SD_DRAG_THRESH && dy < _SD_DRAG_THRESH) return;
+    // Threshold crossed — activate
+    _sd_drag.active = true;
+    document.body.classList.add('schedule-dragging');
+    _sdStartScrollLoop();
+
+    if (_sd_drag.type === 'move') {
+      // Dim the source block
+      _sd_drag.block.classList.add('schedule-item-drag-source');
+      // Build a floating clone that follows the cursor
+      const src  = _sd_drag.block;
+      const rect = src.getBoundingClientRect();
+      const clone = src.cloneNode(true);
+      clone.className = 'schedule-drag-clone';
+      clone.style.width  = src.offsetWidth  + 'px';
+      clone.style.height = src.offsetHeight + 'px';
+      clone.style.top    = rect.top  + 'px';
+      clone.style.left   = rect.left + 'px';
+      document.body.appendChild(clone);
+      _sd_clone = clone;
+    }
+  }
+
+  e.preventDefault();
+
+  if (_sd_drag.type === 'move') {
+    // Update clone position
+    if (_sd_clone) {
+      _sd_clone.style.top = (clientY - _sd_drag.cloneOffsetY) + 'px';
+    }
+
+    if (_sdInTimedArea(clientY)) {
+      const { startMins, endMins } = _sdCalcMove(clientY);
+      _sdShowOutline(startMins, endMins - startMins);
+      _sd_drag.pendingStart = _sdMinsToHHMM(startMins);
+      _sd_drag.pendingEnd   = _sdMinsToHHMM(endMins);
+    } else {
+      _sdHideOutline();
+      _sd_drag.pendingStart = null;
+      _sd_drag.pendingEnd   = null;
+    }
+  } else if (_sd_drag.type === 'resize') {
+    const endMins   = _sdCalcResize(clientY);
+    const startMins = _sd_drag.startMins;
+    // Stretch the block live
+    const h = Math.max(_sdMinsToTopPx(endMins - startMins) - 4, _SD_ROW_H / 2 - 4);
+    _sd_drag.block.style.height = h + 'px';
+    // Show outline shadowing the new size
+    _sdShowOutline(startMins, endMins - startMins);
+    _sd_drag.pendingEnd = _sdMinsToHHMM(endMins);
+  }
+}
+
+// ── Global pointer-up handler ──────────────────────────────────────────────
+
+async function _sdOnUp(e) {
+  if (!_sd_drag) return;
+  const d = _sd_drag;
+  _sd_drag = null;  // clear first so isScheduleDragActive() returns false
+
+  _sdCleanup(d.block);
+
+  if (!d.active) return;  // was just a click — nameSpan.click will fire normally
+
+  if (d.type === 'move' && d.pendingStart && d.pendingEnd) {
+    await _sdCommit(d.item, d.pendingStart, d.pendingEnd);
+  } else if (d.type === 'resize' && d.pendingEnd) {
+    await _sdCommit(d.item, d.item.startTime, d.pendingEnd);
+  }
+}
+
+// ── Pointer-down handlers (attached per block) ─────────────────────────────
+
+function _sdStartMove(e, block, item) {
+  if (e.type === 'mousedown' && e.button !== 0) return;
+  if (e.target.tagName === 'INPUT') return;                         // checkbox
+  if (e.target.classList.contains('schedule-resize-handle')) return; // handled separately
+
+  const { clientX, clientY } = _sdClient(e);
+
+  const durationMins = item.isAllDay
+    ? _SD_ALLDAY_DUR
+    : _sdHHMMtoMins(item.endTime) - _sdHHMMtoMins(item.startTime);
+
+  // How far down the block the user grabbed (so the block doesn't jump)
+  const blockRect    = block.getBoundingClientRect();
+  const cloneOffsetY = clientY - blockRect.top;
+  // Convert that pixel offset to minutes for grid calculation
+  const offsetMins   = item.isAllDay ? 0 : _sdPxToMins(cloneOffsetY);
+
+  _sd_drag = {
+    type: 'move',
+    item, block,
+    startX: clientX, startY: clientY,
+    active: false,
+    durationMins, offsetMins,
+    cloneOffsetY,
+    pendingStart: null, pendingEnd: null,
+  };
+  // Don't preventDefault here — that would kill the nameSpan click event.
+  // It is called in _sdOnMove once DRAG_THRESHOLD is confirmed.
+}
+
+function _sdStartResize(e, block, item) {
+  if (e.type === 'mousedown' && e.button !== 0) return;
+  e.stopPropagation(); // don't also trigger _sdStartMove
+
+  const { clientX, clientY } = _sdClient(e);
+  const startMins = _sdHHMMtoMins(item.startTime);
+
+  _sd_drag = {
+    type: 'resize',
+    item, block,
+    startX: clientX, startY: clientY,
+    active: false,
+    startMins,
+    pendingEnd: null,
+  };
+  // Don't preventDefault here for the same reason.
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+// Called from schedule.js _makeScheduleBlock for every schedule block.
+// `item` is the parsed item descriptor.
+// Timed items get both move and resize handlers; all-day items get move only.
+function attachScheduleDragHandlers(block, item) {
+  // ── Drag-to-move ──────────────────────────────────────────────────────
+  block.addEventListener('mousedown', e => _sdStartMove(e, block, item));
+  block.addEventListener('touchstart', e => _sdStartMove(e, block, item), { passive: true });
+
+  // ── Drag-to-resize (timed items only, via resize handle) ──────────────
+  if (!item.isAllDay) {
+    const handle = block.querySelector('.schedule-resize-handle');
+    if (handle) {
+      handle.addEventListener('mousedown', e => _sdStartResize(e, block, item));
+      handle.addEventListener('touchstart', e => _sdStartResize(e, block, item), { passive: true });
+    }
+  }
+}
+
+// Returns true while a drag or resize is in progress.
+// Called by schedule.js renderSchedule() to defer re-renders.
+function isScheduleDragActive() {
+  return _sd_drag !== null;
+}
+
+// ── Global document listeners (registered once) ────────────────────────────
+// Using document-level listeners so the drag continues even when the mouse
+// leaves the schedule panel, and is cleaned up properly on mouseup anywhere.
+
+document.addEventListener('mousemove', _sdOnMove);
+document.addEventListener('mouseup',   _sdOnUp);
+
+document.addEventListener('touchmove', e => {
+  // Only call preventDefault once the drag is confirmed active,
+  // otherwise we block normal page scroll on touch devices.
+  if (_sd_drag && _sd_drag.active) e.preventDefault();
+  _sdOnMove(e);
+}, { passive: false });
+
+document.addEventListener('touchend',    _sdOnUp, { passive: true });
+document.addEventListener('touchcancel', _sdOnUp, { passive: true });

--- a/web/schedule.js
+++ b/web/schedule.js
@@ -344,6 +344,18 @@ function _makeScheduleBlock(item, extraClass) {
     }, 50);
   });
   block.appendChild(nameSpan);
+
+  // Resize handle — positioned at the bottom of the block.
+  // Hidden via CSS for all-day items; visible (cursor only) for timed items.
+  const resizeHandle = document.createElement('div');
+  resizeHandle.className = 'schedule-resize-handle';
+  block.appendChild(resizeHandle);
+
+  // Drag-to-move and drag-to-resize (schedule-drag.js)
+  if (typeof attachScheduleDragHandlers === 'function') {
+    attachScheduleDragHandlers(block, item);
+  }
+
   return block;
 }
 
@@ -397,6 +409,11 @@ let _renderScheduleRunning = false;
 let _renderScheduleQueued = false;
 
 async function renderSchedule(cachedNotes) {
+  // If a drag is in progress, queue the re-render instead of firing mid-drag.
+  if (typeof isScheduleDragActive === 'function' && isScheduleDragActive()) {
+    _renderScheduleQueued = true;
+    return;
+  }
   // Serialize concurrent calls to prevent timer interleaving
   if (_renderScheduleRunning) {
     _renderScheduleQueued = true;
@@ -581,6 +598,9 @@ async function _doRenderSchedule(cachedNotes) {
     const block = _makeScheduleBlock(item, classes);
     block.style.top    = top + 'px';
     block.style.height = height + 'px';
+    // Store time bounds for conflict detection during drag
+    block.dataset.startMins = startMin;
+    block.dataset.endMins   = endMin;
 
     scheduleGrid.appendChild(block);
   });


### PR DESCRIPTION
Timed items can be dragged to a new time slot (snaps to 15 min increments) and resized by dragging the bottom edge. All-day items dragged onto the timed grid are converted to 30-min timed entries. A dashed drop outline previews placement during drag; the timeline auto-scrolls when the cursor nears the top or bottom edge. All changes write back to the source markdown file (> YYMMDD HHMM HHMM) without disturbing @calendar-tags or task prefix syntax. Clicks on item names are preserved via a 4px drag threshold. Works on mouse and touch. Renders are deferred while a drag is in progress to avoid mid-drag DOM replacement.

https://claude.ai/code/session_01TFj4eBnLxKDqPbs6H9jAd1