### PR TITLE
Fix schedule drag, resize indicator, gs-results border, colour pickers, active note bg, mermaid canvas

### DIFF
--- a/web/css/diagrams.css
+++ b/web/css/diagrams.css
@@ -86,19 +86,26 @@
   opacity: 1;
 }
 
-/* Pan/zoom active state — sizing/position applied via JS; just set visual properties */
+/* Pan/zoom active state — sizing/position applied via JS; just set visual properties.
+   Visually matches the editor/preview container: same background, same padding,
+   toolbar and status bar remain visible above (lower z-index than UI chrome). */
 .mermaid-diagram.mermaid-panzoom-active {
   background: var(--bg);
   user-select: none;
   touch-action: none;
-  /* Small inner padding so the SVG doesn't sit flush against the edge */
-  padding: 36px var(--gap, 10px) var(--gap, 10px);
+  /* Top padding clears the toolbar pill; sides/bottom match --gap */
+  padding: var(--toolbar-h, 48px) var(--gap, 10px) var(--gap, 10px);
   box-sizing: border-box;
 }
 
 .mermaid-diagram.mermaid-panzoom-active svg {
   max-width: none;
   display: block;
+}
+
+/* Keep the panzoom toggle button on top of the canvas content */
+.mermaid-diagram.mermaid-panzoom-active .mermaid-panzoom-btn {
+  z-index: 6;
 }
 
 /* ── Projects note — clickable emoji headings ── */

--- a/web/css/schedule.css
+++ b/web/css/schedule.css
@@ -304,11 +304,9 @@
 
 /* ── Schedule drag-to-move and drag-to-resize ────────────────────────────── */
 
-/* Grab cursor on the block body (hover-capable devices only) */
+/* Grab cursor only on the title span — the only drag handle (hover-capable devices only) */
 @media (hover: hover) {
-  .schedule-item { cursor: grab; }
-  .schedule-item input[type="checkbox"] { cursor: default; }
-  .schedule-event-icon { cursor: grab; }
+  .schedule-item-name { cursor: grab; }
 }
 
 /* Dim the original block while it is being moved */
@@ -372,32 +370,8 @@ body.schedule-dragging * {
   touch-action: none;
 }
 
-/* Subtle grip indicator shown on hover */
-.schedule-resize-handle::after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  top: 3px;
-  transform: translateX(-50%);
-  width: 24px;
-  height: 2px;
-  border-radius: 1px;
-  background: currentColor;
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-
-@media (hover: hover) {
-  .schedule-item:hover .schedule-resize-handle::after { opacity: 0.3; }
-}
-
 /* Hide resize handle inside the all-day section (those items are not resizable) */
 .schedule-allday-section .schedule-resize-handle { display: none; }
-
-/* Larger hit area on touch devices */
-@media (any-pointer: coarse) {
-  .schedule-resize-handle { height: 14px; }
-}
 
 /* Prevent scroll-hijacking on draggable items (touch) */
 .schedule-item { touch-action: pan-y; }

--- a/web/css/search.css
+++ b/web/css/search.css
@@ -124,6 +124,10 @@
   overflow-y: auto;
   flex: 1;
   min-height: 0;
+}
+
+/* Only show the separator when there are results to display */
+#gs-results:has(li) {
   border-top: 1px solid var(--border);
 }
 

--- a/web/css/theme.css
+++ b/web/css/theme.css
@@ -14,10 +14,19 @@
 }
 
 /* Calendar picker: smaller circle */
-.calendar-color-picker { width: 20px; height: 20px; }
+.calendar-color-picker {
+  width: 20px;
+  height: 20px;
+  /* box-shadow ring is more reliable than pseudo-element borders across browsers */
+  box-shadow: 0 0 0 1.5px var(--border);
+}
 
 /* Theme picker: slightly larger */
-.theme-color-picker { width: 28px; height: 28px; }
+.theme-color-picker {
+  width: 28px;
+  height: 28px;
+  box-shadow: 0 0 0 2px var(--border);
+}
 
 .calendar-color-picker::-webkit-color-swatch-wrapper,
 .theme-color-picker::-webkit-color-swatch-wrapper {
@@ -27,13 +36,13 @@
 
 .calendar-color-picker::-webkit-color-swatch,
 .calendar-color-picker::-moz-color-swatch {
-  border: 1px solid var(--border);
+  border: none;
   border-radius: 50%;
 }
 
 .theme-color-picker::-webkit-color-swatch,
 .theme-color-picker::-moz-color-swatch {
-  border: 2px solid var(--border);
+  border: none;
   border-radius: 50%;
 }
 

--- a/web/file-list.js
+++ b/web/file-list.js
@@ -161,15 +161,16 @@ async function _doUpdateFileList() {
     items.push(li);
   }
 
-  // The currently open note is always shown second (after today's note),
-  // displayed in bold but without the highlighted border used for the today
-  // note.  Nav notes (Projects, Note Graph, Settings) are excluded from this
+  // The currently open note is always shown second (after today's note).
+  // It also receives active-file so its background highlights like the
+  // today note does when that is the active note.
+  // Nav notes (Projects, Note Graph, Settings) are excluded from this
   // second slot — they live in the nav-list below and are indicated there.
   const NAV_NAMES = new Set([PROJECTS_NOTE, GRAPH_NOTE, CALENDARS_NOTE]);
   if (currentFileName && noteMap[currentFileName] &&
       currentFileName !== todayNote &&
       !NAV_NAMES.has(currentFileName)) {
-    noteMap[currentFileName].classList.add('second-note');
+    noteMap[currentFileName].classList.add('second-note', 'active-file');
     items.push(noteMap[currentFileName]);
     delete noteMap[currentFileName];
   }

--- a/web/markdown-renderer.js
+++ b/web/markdown-renderer.js
@@ -957,7 +957,10 @@ function setupMermaidPanZoom(wrapper) {
 
     wrapper.classList.add('mermaid-panzoom-active');
     applyFullAreaLayout();
-    wrapper.style.zIndex   = '200';
+    // z-index 4: sits above normal preview content but below the status area
+    // (z-index 5), side panel (z-index 50+), and toolbar (z-index 100) so
+    // that all UI chrome remains visible — matching the editor/view container.
+    wrapper.style.zIndex   = '4';
     wrapper.style.overflow = 'hidden';
     wrapper.style.cursor   = 'grab';
 

--- a/web/schedule-drag.js
+++ b/web/schedule-drag.js
@@ -339,8 +339,6 @@ async function _sdOnUp(e) {
 
 function _sdStartMove(e, block, item) {
   if (e.type === 'mousedown' && e.button !== 0) return;
-  if (e.target.tagName === 'INPUT') return;                         // checkbox
-  if (e.target.classList.contains('schedule-resize-handle')) return; // handled separately
 
   const { clientX, clientY } = _sdClient(e);
 
@@ -419,10 +417,16 @@ function _sdStartResize(e, block, item) {
 // Called from schedule.js _makeScheduleBlock for every schedule block.
 // `item` is the parsed item descriptor.
 // Timed items get both move and resize handlers; all-day items get move only.
+// Drag-to-move is only initiated from the note title (nameSpan) so that
+// accidental moves are avoided — especially on mobile where fat-finger
+// misses are common.  Clicking the title without dragging still navigates.
 function attachScheduleDragHandlers(block, item) {
-  // ── Drag-to-move ──────────────────────────────────────────────────────
-  block.addEventListener('mousedown', e => _sdStartMove(e, block, item));
-  block.addEventListener('touchstart', e => _sdStartMove(e, block, item), { passive: true });
+  // ── Drag-to-move (title span only) ────────────────────────────────────
+  const nameSpan = block.querySelector('.schedule-item-name');
+  if (nameSpan) {
+    nameSpan.addEventListener('mousedown', e => _sdStartMove(e, block, item));
+    nameSpan.addEventListener('touchstart', e => _sdStartMove(e, block, item), { passive: true });
+  }
 
   // ── Drag-to-resize (timed items only, via resize handle) ──────────────
   if (!item.isAllDay) {


### PR DESCRIPTION
- Schedule drag: only allow drag-to-move from the note title span, not the
  whole block body. Cursor grab indicator moved to .schedule-item-name only.
  Touch long-press behaviour preserved; title click for navigation unchanged.

- Schedule resize: remove the grip indicator (::after pseudo-element) and the
  enlarged 14px touch hit area that was blocking taps on 15-min events.

- #gs-results border-top: use :has(li) so the separator line only appears
  when there are actual search results in the list.

- Colour pickers: replace fragile ::-webkit-color-swatch border (unreliable
  in modern Chrome) with a box-shadow ring that always renders correctly.

- Active note background: second-note (currently open non-today note) now also
  receives the active-file class so its background highlights consistently,
  matching the behaviour already in place for today's daily note.

- Mermaid expanded canvas: lower z-index from 200 to 4 so the toolbar
  (z-index 100), side-panel buttons (z-index 100), and status messages
  (z-index 5) all remain visible above the canvas — matching the editor/
  preview container visually. Top padding updated to clear the toolbar pill.
  Panzoom button z-index bumped to stay above the canvas content.

https://claude.ai/code/session_01M3nAZ8GNvuZabZYZaWtnnt