### PR TITLE
Fix UI bugs: mermaid button, schedule all-day drag, panel button, colour pickers, highlight animation, new note popup

### DIFF
--- a/web/app-init.js
+++ b/web/app-init.js
@@ -641,7 +641,8 @@ const _RE_AC_MD   = /\[[^\[\]\n]*\]\(([^)\n]*)$/;
       'font:' + cs.font + ';padding:' + cs.padding + ';border:' + cs.border + ';' +
       'width:' + textarea.offsetWidth + 'px;line-height:' + cs.lineHeight + ';';
     // Measure right after the opening trigger — stays fixed while typing.
-    const anchorOffset = _acMode === 'wiki' ? _acStart + 2 : _acStart + 1;
+    // wiki: skip past [[  (2 chars); md: skip past (  (1 char); new-note: already at title start.
+    const anchorOffset = _acMode === 'wiki' ? _acStart + 2 : _acMode === 'md' ? _acStart + 1 : _acStart;
     mirror.appendChild(document.createTextNode(textarea.value.slice(0, anchorOffset)));
     const anchor = document.createElement('span');
     anchor.textContent = '\u200b';
@@ -673,6 +674,28 @@ const _RE_AC_MD   = /\[[^\[\]\n]*\]\(([^)\n]*)$/;
   }
 
   function _complete(name) {
+    // New-note mode: either load an existing note or insert the chosen title.
+    if (_acMode === 'new-note') {
+      _hide();
+      NoteStorage.getNote(name).then(content => {
+        if (content !== null) {
+          // Existing note selected — load it immediately.
+          loadNote(name);
+        } else {
+          // Non-existing name — insert it as the note title (no link markup).
+          const curPos = textarea.selectionStart;
+          const before = textarea.value.slice(0, _acStart); // '# '
+          const after  = textarea.value.slice(curPos);
+          textarea.value = before + name + after;
+          const newPos = before.length + name.length;
+          textarea.selectionStart = textarea.selectionEnd = newPos;
+          textarea.focus();
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      });
+      return;
+    }
+
     const pos = textarea.selectionStart;
     const before = textarea.value.slice(0, _acStart);
     const after  = textarea.value.slice(pos);
@@ -740,6 +763,45 @@ const _RE_AC_MD   = /\[[^\[\]\n]*\]\(([^)\n]*)$/;
     });
   }
 
+  // ── New-note filename suggestions ─────────────────────────────────────────
+  // Shows existing note names when the user is typing a title for a brand-new
+  // note (currentFileName === null, cursor on the first line after '# ').
+  // Selecting an existing note instantly loads it; typing a fresh name is unaffected.
+  function _handleNewNoteTrigger(partial, titleStart) {
+    _acStart = titleStart;
+    _acMode = 'new-note';
+    NoteStorage.getAllNoteNames().then(names => {
+      const normPartial = partial.toLowerCase();
+      const VIRTUAL = new Set([PROJECTS_NOTE, GRAPH_NOTE, CALENDARS_NOTE]);
+      const filtered = names
+        .filter(n => !n.startsWith('.') && !VIRTUAL.has(n))
+        .filter(n => !normPartial || n.toLowerCase().includes(normPartial))
+        .sort((a, b) => {
+          if (!normPartial) return b.localeCompare(a); // reverse-alpha (newest first) with no filter
+          const as = a.toLowerCase().startsWith(normPartial);
+          const bs = b.toLowerCase().startsWith(normPartial);
+          return (bs - as) || a.localeCompare(b);
+        })
+        .slice(0, 10);
+      if (filtered.length === 0) { _hide(); return; }
+      _acItems = filtered;
+      _acWantedSet = new Set();
+      _acIdx = 0;
+      _renderDropdown(filtered, new Set());
+      _positionDropdown();
+    });
+  }
+
+  // Expose a trigger so newNote() can open the popup immediately on creation.
+  window._triggerNewNoteDropdown = function() {
+    if (currentFileName !== null) return;
+    const firstLine = textarea.value.split('\n')[0];
+    const m = firstLine.match(/^#\s+(.*)/);
+    const partial = m ? m[1] : '';
+    const titleStart = firstLine.indexOf(' ') + 1; // position after '# '
+    _handleNewNoteTrigger(partial, titleStart);
+  };
+
   textarea.addEventListener('input', () => {
     const pos = textarea.selectionStart;
     const before = textarea.value.slice(0, pos);
@@ -758,6 +820,21 @@ const _RE_AC_MD   = /\[[^\[\]\n]*\]\(([^)\n]*)$/;
       const acStart = before.length - mdM[1].length - 1;
       _handleMatch(mdM[1].toLowerCase(), acStart, 'md');
       return;
+    }
+
+    // Priority 3: new-note mode — typing the title for a brand-new note
+    if (currentFileName === null) {
+      const firstLineEnd = textarea.value.indexOf('\n');
+      const onFirstLine = firstLineEnd === -1 || pos <= firstLineEnd;
+      if (onFirstLine) {
+        const firstLine = firstLineEnd === -1 ? textarea.value : textarea.value.slice(0, firstLineEnd);
+        const titleM = firstLine.match(/^#\s+(.*)/);
+        if (titleM) {
+          const titleStart = firstLine.indexOf(' ') + 1; // char index after '# '
+          _handleNewNoteTrigger(titleM[1], titleStart);
+          return;
+        }
+      }
     }
 
     _hide();

--- a/web/app-state.js
+++ b/web/app-state.js
@@ -605,7 +605,7 @@ function highlightTextInPreview(text, caseSensitive = false, occurrenceIndex = 0
         expandCollapsedAncestors(el);
         el.classList.add('schedule-highlight');
         el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-        setTimeout(() => el.classList.remove('schedule-highlight'), 2000);
+        el.addEventListener('animationend', () => el.classList.remove('schedule-highlight'), { once: true });
         return;
       }
       lastMatch = el;
@@ -616,6 +616,6 @@ function highlightTextInPreview(text, caseSensitive = false, occurrenceIndex = 0
     expandCollapsedAncestors(lastMatch);
     lastMatch.classList.add('schedule-highlight');
     lastMatch.scrollIntoView({ block: 'center', behavior: 'smooth' });
-    setTimeout(() => lastMatch.classList.remove('schedule-highlight'), 2000);
+    lastMatch.addEventListener('animationend', () => lastMatch.classList.remove('schedule-highlight'), { once: true });
   }
 }

--- a/web/css/diagrams.css
+++ b/web/css/diagrams.css
@@ -103,9 +103,11 @@
   display: block;
 }
 
-/* Keep the panzoom toggle button on top of the canvas content */
+/* Keep the panzoom toggle button on top of the canvas content,
+   and shift it below the floating toolbar when expanded. */
 .mermaid-diagram.mermaid-panzoom-active .mermaid-panzoom-btn {
   z-index: 6;
+  top: calc(var(--toolbar-h, 45px) + 8px);
 }
 
 /* ── Projects note — clickable emoji headings ── */

--- a/web/css/panels.css
+++ b/web/css/panels.css
@@ -122,8 +122,10 @@ body.panel-visible #panel-arrow {
   background-color: var(--surface);
 }
 
-/* Hide when panel is pinned (pin button takes over that spot) */
-body.panel-pinned #panel-open-btn {
+/* Hide when panel is pinned (pin button takes over that spot),
+   or when the panel is visible so the button doesn't show during the bounce animation. */
+body.panel-pinned #panel-open-btn,
+body.panel-visible #panel-open-btn {
   display: none;
 }
 

--- a/web/css/preview.css
+++ b/web/css/preview.css
@@ -277,19 +277,28 @@
     max-height: 40vh;
   }
 }
-/* ── Schedule / search navigation highlight (flashes then fades) ── */
-#preview .schedule-highlight {
-  background-color: var(--sched-highlight-bg);
-  border-radius: 3px;
-  outline: 2px solid var(--sched-highlight-outline);
-  transition: background-color 1.5s ease, outline-color 1.5s ease;
+/* ── Schedule / search navigation highlight (floats then fades) ── */
+/* Mirrors the copy-float animation from file-list.css — brief box-shadow
+   lift so the highlighted paragraph visually surfaces without colour flash. */
+@keyframes preview-nav-float {
+  0%   { box-shadow: none; }
+  15%  { box-shadow: 0 1px 4px var(--shadow), 0 6px 20px var(--shadow-light); }
+  70%  { box-shadow: 0 1px 4px var(--shadow), 0 6px 20px var(--shadow-light); }
+  100% { box-shadow: none; }
 }
 
-/* Inside <summary> the highlight must appear/disappear instantly (no fade),
-   so collapsed sections snap in and out without a lingering glow. */
+#preview .schedule-highlight {
+  border-radius: 4px;
+  position: relative;
+  z-index: 1;
+  animation: preview-nav-float 1.4s ease-out forwards;
+}
+
+/* Inside <summary> the highlight must appear/disappear instantly (no animation),
+   so collapsed sections snap in and out cleanly. */
 #preview summary .schedule-highlight,
 #preview summary.schedule-highlight {
-  transition: none;
+  animation: none;
 }
 
 /* ── Highlight syntax (==text==) ── */

--- a/web/css/schedule.css
+++ b/web/css/schedule.css
@@ -376,3 +376,11 @@ body.schedule-dragging * {
 /* Prevent scroll-hijacking on draggable items (touch) */
 .schedule-item { touch-action: pan-y; }
 .schedule-allday-section .schedule-item { touch-action: pan-y; }
+
+/* Drop-target highlight when a timed item is dragged over the all-day section */
+.schedule-allday-section.schedule-allday-drop-target {
+  outline: 2px dashed var(--sched-item-border);
+  outline-offset: -2px;
+  border-radius: 5px;
+  background: var(--sched-item-bg);
+}

--- a/web/css/theme.css
+++ b/web/css/theme.css
@@ -11,6 +11,8 @@
   vertical-align: middle;
   margin-left: 6px;
   flex-shrink: 0;
+  outline: none;
+  overflow: hidden; /* clip browser's default square swatch border to the circle shape */
 }
 
 /* Calendar picker: smaller circle */

--- a/web/note-manager.js
+++ b/web/note-manager.js
@@ -742,6 +742,13 @@ async function newNote() {
     textarea.setSelectionRange('# '.length, '# '.length);
   }
   updateFileList();
+  // Show the filename suggestion popup so the user can see available note names
+  // and quickly open an existing note instead of creating a duplicate.
+  requestAnimationFrame(() => {
+    if (typeof window._triggerNewNoteDropdown === 'function') {
+      window._triggerNewNoteDropdown();
+    }
+  });
 }
 
 async function deleteNote() {

--- a/web/schedule-drag.js
+++ b/web/schedule-drag.js
@@ -79,6 +79,15 @@ function _sdClient(e) {
 
 // ── Markdown write-back ────────────────────────────────────────────────────
 
+// Removes the HHMM HHMM tokens from a timed line, converting it to an
+// all-day line (> YYMMDD). Preserves the task prefix and @calendar-tag.
+// Returns the updated line, or null if the pattern isn't found.
+function _sdTimedToAlldayLine(line) {
+  const re = /(>\s*\d{6})\s+\d{4}\s+\d{4}((?:\s+@\S+)*)\s*$/;
+  if (!re.test(line)) return null;
+  return line.replace(re, (_, datePart, tags) => `${datePart}${tags}`);
+}
+
 // Replaces the HHMM HHMM portion of a timed schedule line, preserving
 // everything else (task prefix, date, @calendar-tag).
 // Returns the updated line string, or null if the line doesn't match.
@@ -111,6 +120,34 @@ async function _sdCommit(item, newStart, newEnd) {
   } else {
     updated = _sdReplaceTimedLine(lines[item.lineIndex], newStart, newEnd);
   }
+  if (!updated || updated === lines[item.lineIndex]) return;
+
+  lines[item.lineIndex] = updated;
+  const newContent = lines.join('\n');
+  await NoteStorage.setNote(item.fileName, newContent);
+
+  if (currentFileName === item.fileName) {
+    textarea.value = newContent;
+    if (isPreview || projectsViewActive) {
+      if (typeof renderPreview === 'function') renderPreview();
+    } else {
+      if (typeof refreshHighlight === 'function') refreshHighlight();
+    }
+  }
+
+  invalidateScheduleCache();
+  await renderSchedule();
+}
+
+// Converts a timed item back to an all-day item by stripping HHMM tokens.
+async function _sdCommitToAllday(item) {
+  if (item.isAllDay) return; // already all-day; nothing to do
+  const content = await NoteStorage.getNote(item.fileName);
+  if (!content) return;
+  const lines = content.split('\n');
+  if (item.lineIndex < 0 || item.lineIndex >= lines.length) return;
+
+  const updated = _sdTimedToAlldayLine(lines[item.lineIndex]);
   if (!updated || updated === lines[item.lineIndex]) return;
 
   lines[item.lineIndex] = updated;
@@ -219,6 +256,20 @@ function _sdInTimedArea(clientY) {
   return clientY >= r.top && clientY <= r.bottom;
 }
 
+// True when clientY is within the all-day section.
+function _sdInAlldayArea(clientY) {
+  const section = document.querySelector('.schedule-allday-section');
+  if (!section) return false;
+  const r = section.getBoundingClientRect();
+  return clientY >= r.top && clientY <= r.bottom;
+}
+
+// Add/remove the visual drop-target highlight on the all-day section.
+function _sdHighlightAllday(on) {
+  const section = document.querySelector('.schedule-allday-section');
+  if (section) section.classList.toggle('schedule-allday-drop-target', on);
+}
+
 // ── Drag-to-resize helpers ─────────────────────────────────────────────────
 
 function _sdCalcResize(clientY) {
@@ -234,6 +285,7 @@ function _sdCalcResize(clientY) {
 function _sdCleanup(block) {
   _sdStopScrollLoop();
   _sdRemoveOutline();
+  _sdHighlightAllday(false);
   document.body.classList.remove('schedule-dragging');
   if (_sd_clone) { _sd_clone.remove(); _sd_clone = null; }
   if (block)     { block.classList.remove('schedule-item-drag-source'); }
@@ -297,12 +349,23 @@ function _sdOnMove(e) {
     if (_sdInTimedArea(clientY)) {
       const { startMins, endMins } = _sdCalcMove(clientY);
       _sdShowOutline(startMins, endMins - startMins);
-      _sd_drag.pendingStart = _sdMinsToHHMM(startMins);
-      _sd_drag.pendingEnd   = _sdMinsToHHMM(endMins);
+      _sd_drag.pendingStart    = _sdMinsToHHMM(startMins);
+      _sd_drag.pendingEnd      = _sdMinsToHHMM(endMins);
+      _sd_drag.pendingToAllday = false;
+      _sdHighlightAllday(false);
+    } else if (!_sd_drag.item.isAllDay && _sdInAlldayArea(clientY)) {
+      // Timed item dragged over the all-day section — offer to convert it
+      _sdHideOutline();
+      _sd_drag.pendingStart    = null;
+      _sd_drag.pendingEnd      = null;
+      _sd_drag.pendingToAllday = true;
+      _sdHighlightAllday(true);
     } else {
       _sdHideOutline();
-      _sd_drag.pendingStart = null;
-      _sd_drag.pendingEnd   = null;
+      _sdHighlightAllday(false);
+      _sd_drag.pendingStart    = null;
+      _sd_drag.pendingEnd      = null;
+      _sd_drag.pendingToAllday = false;
     }
   } else if (_sd_drag.type === 'resize') {
     const endMins   = _sdCalcResize(clientY);
@@ -328,7 +391,9 @@ async function _sdOnUp(e) {
 
   if (!d.active) return;  // was just a click — nameSpan.click will fire normally
 
-  if (d.type === 'move' && d.pendingStart && d.pendingEnd) {
+  if (d.type === 'move' && d.pendingToAllday) {
+    await _sdCommitToAllday(d.item);
+  } else if (d.type === 'move' && d.pendingStart && d.pendingEnd) {
     await _sdCommit(d.item, d.pendingStart, d.pendingEnd);
   } else if (d.type === 'resize' && d.pendingEnd) {
     await _sdCommit(d.item, d.item.startTime, d.pendingEnd);
@@ -360,6 +425,7 @@ function _sdStartMove(e, block, item) {
     durationMins, offsetMins,
     cloneOffsetY,
     pendingStart: null, pendingEnd: null,
+    pendingToAllday: false,
     touchTimer: null, touchReady: false,
   };
 


### PR DESCRIPTION
- Mermaid expanded view: position uncollapse button below the floating
  toolbar using calc(--toolbar-h + 8px) so it's reachable when panzoom
  is active.

- Schedule view: timed items can now be dragged back into the all-day
  section. Adds _sdTimedToAlldayLine(), _sdCommitToAllday(),
  _sdInAlldayArea(), and _sdHighlightAllday() helpers. A dashed outline
  highlights the all-day section as the target during drag.

- Panel open button: hide immediately when panel-visible is set so the
  button doesn't remain visible during the bounce-in animation.

- Colour pickers in Settings: add overflow:hidden and outline:none to
  clip the browser's default square swatch border to the circle shape.

- Link-click highlight (schedule, tasks, find & replace): replace the
  background-colour + outline flash with a box-shadow float animation
  (preview-nav-float) matching the copy-note-name behaviour. Uses
  animationend to auto-remove the class.

- New note popup: when creating a new note, show the wikilink dropdown
  populated with existing note names. Selecting an existing note loads
  it instantly; typing a new title continues as normal.

https://claude.ai/code/session_019a4phRN632RHkuXue7wUyK