### PR TITLE
Improve status pill animation smoothness

### DIFF
--- a/web/app-state.js
+++ b/web/app-state.js
@@ -328,21 +328,34 @@ function _animatePillResize(pillEl, changeFn) {
   _pillResizeTimer = setTimeout(() => {
     pillEl.style.width = '';
     _pillResizeTimer = null;
-  }, 350);
+  }, 280);
 }
 
 // persistent=true: message stays visible until next updateStatus call
 function updateStatus(message, success, persistent = false) {
   const pillEl = document.getElementById('bottom-status-area');
-  // Restore visibility before measuring so _animatePillResize always sees the
-  // pill as live — this lets consecutive messages animate smoothly even if the
-  // previous one had already started fading out.
-  if (pillEl) { pillEl.style.opacity = '1'; pillEl.style.pointerEvents = ''; }
+  // Remove any active scroll-fade first so its !important opacity override cannot
+  // mask the restore below, then make the pill live so _animatePillResize sees it.
+  if (pillEl) { pillEl.classList.remove('scroll-faded'); pillEl.style.opacity = '1'; pillEl.style.pointerEvents = ''; }
+
+  // Cross-fade the label when a message is already showing: dip text opacity to 0,
+  // change content while invisible, then fade back in via double-rAF so the browser
+  // commits the new text node before the transition reverses.
+  const wasVisible = statusDiv.style.opacity === '1';
+  if (wasVisible) statusDiv.style.opacity = '0';
+
   _animatePillResize(pillEl, () => {
     statusDiv.textContent = toTitleCase(message);
     statusDiv.style.color = success ? 'var(--success)' : 'var(--error)';
-    statusDiv.style.opacity = '1';
+    if (!wasVisible) statusDiv.style.opacity = '1';
   });
+
+  if (wasVisible) {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => { statusDiv.style.opacity = '1'; });
+    });
+  }
+
   if (statusTimeout) clearTimeout(statusTimeout);
   if (persistent) {
     statusTimeout = null;

--- a/web/css/toolbar.css
+++ b/web/css/toolbar.css
@@ -12,10 +12,12 @@
   pointer-events: none;
   transition: opacity 0.35s cubic-bezier(0.34, 1.4, 0.64, 1),
               left 0.3s cubic-bezier(0.34, 1.4, 0.64, 1),
-              width 0.25s ease;
+              width 0.25s ease,
+              transform 0.3s cubic-bezier(0.34, 1.4, 0.64, 1);
   white-space: nowrap;
   z-index: 5;
   box-shadow: 0 1px 4px var(--shadow), 0 6px 20px var(--shadow-light);
+  will-change: opacity, transform;
 }
 
 /* Suppress position (left/width) transitions when pin state changes while


### PR DESCRIPTION
- Fix scroll-faded conflict: classList.remove('scroll-faded') in
  updateStatus so a new message immediately cancels the scroll fade
  instead of being silently masked by the !important override
- Add text cross-fade: dip statusDiv opacity to 0 before changing
  content when pill is already visible, then restore via double-rAF
  so old text fades out and new text fades in
- Add transform to base CSS transition so the translateY(8px) offset
  from scroll-faded animates back smoothly rather than snapping
- Add will-change: opacity, transform for GPU layer promotion
- Tighten _pillResizeTimer from 350ms to 280ms to match the 250ms
  width CSS transition more closely

https://claude.ai/code/session_01NzihXzpfmVAaSS3DszbwsW