### PR TITLE
Fix table row ghost text disappearing and add chain-insert on Enter

### DIFF
--- a/web/syntax-highlight.js
+++ b/web/syntax-highlight.js
@@ -65,6 +65,9 @@ function _updateHighlight() {
   if (_searchMatchIdx >= 0 && _searchMatchLen > 0) {
     _applySearchHighlight();
   }
+  // Re-inject table row ghost text after every highlight refresh so it survives
+  // innerHTML rewrites caused by typing, auto-save, calendar sync, etc.
+  if (typeof window._tableGhostApply === 'function') window._tableGhostApply();
 }
 
 // Walk the pre's text nodes and wrap the character range in a <mark>.

--- a/web/table-features.js
+++ b/web/table-features.js
@@ -921,8 +921,16 @@ function _fallbackCopy(text, glowTarget) {
     const lineStart = text.lastIndexOf('\n', pos - 1) + 1;
     const currentLine = text.slice(lineStart, pos);
 
-    // Only trigger when the current line is exactly '|'
-    if (currentLine !== '|') { _trHide(); return; }
+    // Keep suggestion visible when user types a space after '|' and a suggestion
+    // is already active — just shift the ghost insertion point forward by one.
+    if (currentLine === '| ' && _trSuggestion !== null) {
+      _ghostInsertPos = pos;
+      _ghostText = _trSuggestion.slice(2); // show remaining text after '| '
+      return; // ghost will be re-injected by _updateHighlight → _tableGhostApply
+    }
+
+    // Trigger on '|' or '| ' (pipe with optional space, e.g. after Enter-accepted row)
+    if (currentLine !== '|' && currentLine !== '| ') { _trHide(); return; }
 
     const linesAbove = text.slice(0, lineStart).split('\n');
     // text.slice(0, lineStart) always ends with \n so split always has a trailing
@@ -934,7 +942,16 @@ function _fallbackCopy(text, glowTarget) {
     const suggestion = _buildSuggestion(bodyRows);
     if (!suggestion) { _trHide(); return; }
 
-    _trShow(pos, suggestion);
+    if (currentLine === '| ') {
+      // Fresh suggestion on a '| ' line (e.g., auto-inserted after accepting a row)
+      _trHide();
+      _trSuggestion   = suggestion;
+      _ghostInsertPos = pos;
+      _ghostText      = suggestion.slice(2); // skip '| ' already typed
+      setTimeout(_applyGhostToPre, 50);
+    } else {
+      _trShow(pos, suggestion);
+    }
   });
 
   textarea.addEventListener('keydown', e => {
@@ -948,7 +965,7 @@ function _fallbackCopy(text, glowTarget) {
       const suggestion = _trSuggestion; // capture before _trHide() nulls it
       _trHide();
       textarea.setSelectionRange(lineStart, pos);
-      document.execCommand('insertText', false, suggestion + '\n');
+      document.execCommand('insertText', false, suggestion + '\n| ');
       textarea.focus();
     } else if (e.key === 'Escape') {
       e.stopPropagation();
@@ -957,4 +974,8 @@ function _fallbackCopy(text, glowTarget) {
   }, true); // capture phase — same priority as wiki dropdown
 
   textarea.addEventListener('blur', () => setTimeout(_trHide, 150));
+
+  // Expose ghost-reapply hook so _updateHighlight in syntax-highlight.js can
+  // re-inject the ghost span after every innerHTML refresh without a fixed delay.
+  window._tableGhostApply = _applyGhostToPre;
 }


### PR DESCRIPTION
- Ghost text now survives every innerHTML refresh: _updateHighlight calls
  window._tableGhostApply after rewriting the pre so the ghost span is
  re-injected after calendar sync, auto-save, and any other highlight update,
  not just the initial 50 ms timeout after the user types '|'.

- Ghost stays visible when the user types a space after '|': the '| '
  line is recognised as a continuation of the active suggestion; the ghost
  insertion point and text are shifted forward by one character so the
  faded preview tracks the cursor as the user types the pipe + space prefix.

- Pressing Enter to accept a row now inserts '| ' on the new line so the
  user can keep pressing Enter to chain-insert predicted rows without having
  to type the opening pipe each time.

https://claude.ai/code/session_01SCBBimf2X3AEgbGRGgVpmf