### PR TITLE
claude/fix-mermaid-button-alignment-7go1x

### DIFF
--- a/web/app-state.js
+++ b/web/app-state.js
@@ -301,6 +301,9 @@ function saveChain() {
 // Smoothly animate the pill to its new natural width after a content change.
 // Only animates when the pill is explicitly visible (style.opacity === '1').
 let _pillResizeTimer = null;
+// In-flight cross-fade delay for updateStatus content swaps.
+let _crossFadeTimer = null;
+
 function _animatePillResize(pillEl, changeFn) {
   if (!pillEl || pillEl.style.opacity !== '1') { changeFn(); return; }
 
@@ -334,36 +337,49 @@ function _animatePillResize(pillEl, changeFn) {
 // persistent=true: message stays visible until next updateStatus call
 function updateStatus(message, success, persistent = false) {
   const pillEl = document.getElementById('bottom-status-area');
-  // Remove any active scroll-fade first so its !important opacity override cannot
-  // mask the restore below, then make the pill live so _animatePillResize sees it.
+
+  // Cancel any in-flight cross-fade and auto-hide timers so a rapid sequence
+  // of calls always converges on the latest message without stale side-effects.
+  if (_crossFadeTimer) { clearTimeout(_crossFadeTimer); _crossFadeTimer = null; }
+  if (statusTimeout)   { clearTimeout(statusTimeout);   statusTimeout   = null; }
+
+  // Remove any active scroll-fade so its !important opacity cannot mask the
+  // restore below, then make the pill live so _animatePillResize can see it.
   if (pillEl) { pillEl.classList.remove('scroll-faded'); pillEl.style.opacity = '1'; pillEl.style.pointerEvents = ''; }
 
-  // Cross-fade the label when a message is already showing: dip text opacity to 0,
-  // change content while invisible, then fade back in via double-rAF so the browser
-  // commits the new text node before the transition reverses.
-  const wasVisible = statusDiv.style.opacity === '1';
-  if (wasVisible) statusDiv.style.opacity = '0';
-
-  _animatePillResize(pillEl, () => {
-    statusDiv.textContent = toTitleCase(message);
-    statusDiv.style.color = success ? 'var(--success)' : 'var(--error)';
-    if (!wasVisible) statusDiv.style.opacity = '1';
-  });
-
-  if (wasVisible) {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => { statusDiv.style.opacity = '1'; });
+  // Inner helper: swap text content, animate pill width, then fade text in.
+  // Also schedules the auto-hide timer (unless persistent).
+  function applyMessage() {
+    _animatePillResize(pillEl, () => {
+      statusDiv.textContent = toTitleCase(message);
+      statusDiv.style.color = success ? 'var(--success)' : 'var(--error)';
     });
+    // Fade text in on the next frame so the browser has committed the new
+    // text node and the CSS transition fires cleanly.
+    requestAnimationFrame(() => { statusDiv.style.opacity = '1'; });
+
+    if (!persistent) {
+      statusTimeout = setTimeout(() => {
+        statusDiv.style.opacity = '0';
+        if (pillEl) { pillEl.style.opacity = '0'; pillEl.style.pointerEvents = 'none'; }
+      }, 3000);
+    }
   }
 
-  if (statusTimeout) clearTimeout(statusTimeout);
-  if (persistent) {
-    statusTimeout = null;
+  // Cross-fade when a message is already visible: fade the text out fully
+  // first (150 ms — matches #status-message transition in toolbar.css), then
+  // swap the content and animate the pill to its new size.  This avoids the
+  // brief "empty-pill" artefact of the old double-rAF approach and gives a
+  // clear sequential animation: out → resize + in.
+  const wasVisible = statusDiv.style.opacity === '1';
+  if (wasVisible) {
+    statusDiv.style.opacity = '0';
+    _crossFadeTimer = setTimeout(() => {
+      _crossFadeTimer = null;
+      applyMessage();
+    }, 150);
   } else {
-    statusTimeout = setTimeout(() => {
-      statusDiv.style.opacity = '0';
-      if (pillEl) { pillEl.style.opacity = '0'; pillEl.style.pointerEvents = 'none'; }
-    }, 3000);
+    applyMessage();
   }
 }
 

--- a/web/css/diagrams.css
+++ b/web/css/diagrams.css
@@ -60,11 +60,15 @@
   height: auto;
 }
 
-/* Pan/zoom toggle button — top-left corner, always visible */
+/* Pan/zoom toggle button — aligned with note text content (left: --gap matches
+   the margin-left applied to regular preview elements). This stays correct even
+   when the diagram is expanded to full-area, because the expanded wrapper is
+   fixed to the editor-section's left edge and --gap pushes the button to the
+   same visual column as all other content. */
 .mermaid-panzoom-btn {
   position: absolute;
   top: 5px;
-  left: 5px;
+  left: var(--gap, 10px);
   z-index: 5;
   display: flex;
   align-items: center;

--- a/web/css/theme.css
+++ b/web/css/theme.css
@@ -2,6 +2,7 @@
 .calendar-color-picker,
 .theme-color-picker {
   -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
   border: none;
   border-radius: 50%;
@@ -12,7 +13,17 @@
   margin-left: 6px;
   flex-shrink: 0;
   outline: none;
-  overflow: hidden; /* clip browser's default square swatch border to the circle shape */
+  /* overflow:hidden clips the browser's default square-cornered swatch frame to
+     our circular shape on all platforms */
+  overflow: hidden;
+  /* Suppress any lingering focus ring — the box-shadow ring is the only border */
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Suppress focus indicator; the box-shadow ring communicates the shape */
+.calendar-color-picker:focus,
+.theme-color-picker:focus {
+  outline: none;
 }
 
 /* Calendar picker: smaller circle */
@@ -30,19 +41,31 @@
   box-shadow: 0 0 0 2px var(--border);
 }
 
+/* Chromium / Electron / Safari WebKit —————————————————————————————————————
+   The swatch-wrapper defaults to padding:2px and has its own border, which
+   produces a visible gap (inner ring) between the colour fill and the
+   box-shadow outline ring.  Force it to fill the full input circle. */
 .calendar-color-picker::-webkit-color-swatch-wrapper,
 .theme-color-picker::-webkit-color-swatch-wrapper {
   padding: 0;
+  border: none;
   border-radius: 50%;
+  width: 100%;
+  height: 100%;
 }
 
 .calendar-color-picker::-webkit-color-swatch,
-.calendar-color-picker::-moz-color-swatch {
+.theme-color-picker::-webkit-color-swatch {
   border: none;
   border-radius: 50%;
+  /* Ensure the colour fill covers the full circle, no inner padding gap */
+  width: 100%;
+  height: 100%;
+  min-height: unset;
 }
 
-.theme-color-picker::-webkit-color-swatch,
+/* Firefox ————————————————————————————————————————————————————————————————— */
+.calendar-color-picker::-moz-color-swatch,
 .theme-color-picker::-moz-color-swatch {
   border: none;
   border-radius: 50%;

--- a/web/css/toolbar.css
+++ b/web/css/toolbar.css
@@ -17,13 +17,19 @@
   white-space: nowrap;
   z-index: 5;
   box-shadow: 0 1px 4px var(--shadow), 0 6px 20px var(--shadow-light);
-  will-change: opacity, transform;
+  /* Include width so the browser promotes the pill to its own compositor
+     layer, keeping width animations smooth across all platforms (including
+     iOS where position:fixed + width transition can otherwise stutter). */
+  will-change: opacity, transform, width;
 }
 
 /* Suppress position (left/width) transitions when pin state changes while
-   the panel is already visible — pill repositions instantly. */
+   the panel is already visible — pill repositions instantly.
+   Width transition is intentionally preserved so content changes still
+   animate smoothly even when position transitions are suppressed. */
 #bottom-status-area.no-position-transition {
-  transition: opacity 0.35s cubic-bezier(0.34, 1.4, 0.64, 1) !important;
+  transition: opacity 0.35s cubic-bezier(0.34, 1.4, 0.64, 1),
+              width 0.25s ease !important;
 }
 
 #bottom-status-area[style*="cursor: pointer"]:hover {
@@ -40,7 +46,9 @@
   white-space: nowrap;
   color: var(--muted);
   opacity: 0;
-  transition: opacity 0.4s ease;
+  /* 150ms matches the JS cross-fade delay in updateStatus() so the text fully
+     fades out before the new content and pill-resize animation begin. */
+  transition: opacity 0.15s ease;
   padding: 1.5px 0;
 }
 


### PR DESCRIPTION
- diagrams.css: Move .mermaid-panzoom-btn left position from hard-coded 5px to
  var(--gap, 10px) so the button aligns with where text content starts in the
  note preview, both in the normal and expanded (full-area) states.

- theme.css: Eliminate multiple-border artefacts on colour picker circles.
  Add -moz-appearance:none and -webkit-tap-highlight-color:transparent; add
  explicit :focus outline suppression; set width/height:100% and border:none on
  ::-webkit-color-swatch-wrapper (Chromium default padding:2px caused a visible
  gap between the colour fill and the box-shadow ring); add min-height:unset on
  the swatch itself to prevent inner sizing bugs on Electron/Safari.

- toolbar.css: Add width to will-change so the browser promotes the pill to its
  own compositor layer, smoothing width animations on iOS fixed-position elements.
  Fix .no-position-transition to explicitly keep the width transition (previously
  the !important override stripped it entirely).  Reduce #status-message opacity
  transition from 0.4s to 0.15s to coordinate with the JS cross-fade delay.

- app-state.js: Rewrite updateStatus cross-fade logic.  Previously a double-rAF
  (~33ms) caused the new text to barely dip before reappearing, resulting in a
  jittery snap.  New approach: fade text to 0 fully (150ms), then swap content
  and animate pill to new width simultaneously, then fade text back in — a clean
  sequential out→resize+in animation.  Also add _crossFadeTimer so rapid calls
  cancel in-flight delays and always converge on the latest message.  Move the
  auto-hide statusTimeout setup into applyMessage() so the 3s countdown starts
  when the new content actually becomes visible.

https://claude.ai/code/session_01CpVEWtC84eGax3YiURZ2wG