### PR TITLE
Fix table ghost text doubling by removing span instead of unwrapping it

### DIFF
--- a/web/js/editor/table-features.js
+++ b/web/js/editor/table-features.js
@@ -519,10 +519,7 @@ function _fallbackCopy(text, glowTarget) {
   // Remove the ghost span from the pre.  Synchronous — safe to call in input handler.
   function _trHide() {
     if (typeof _highlightPre !== 'undefined' && _highlightPre) {
-      _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => {
-        while (s.firstChild) s.parentNode.insertBefore(s.firstChild, s);
-        s.parentNode.removeChild(s);
-      });
+      _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => s.remove());
     }
     _ghostInsertPos = null;
     _ghostText      = '';
@@ -535,10 +532,7 @@ function _fallbackCopy(text, glowTarget) {
   function _applyGhostToPre() {
     if (_ghostInsertPos === null || typeof _highlightPre === 'undefined' || !_highlightPre) return;
     // Remove any stale ghost span.
-    _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => {
-      while (s.firstChild) s.parentNode.insertBefore(s.firstChild, s);
-      s.parentNode.removeChild(s);
-    });
+    _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => s.remove());
     // Walk text nodes to find the character offset.
     const walker = document.createTreeWalker(_highlightPre, NodeFilter.SHOW_TEXT);
     let remaining = _ghostInsertPos;


### PR DESCRIPTION
The old "unwrap" removal pattern moved the ghost span's synthetic text
content into the parent as a plain text node before deleting the span.
When _applyGhostToPre fired a second time (50 ms setTimeout after the
initial call from _updateHighlight at ~10 ms), the orphaned ghost text
remained visible in normal colour while a new faded ghost span was also
injected, causing the briefly doubled text the user saw.

Replacing both unwrap loops with s.remove() deletes the span and its
synthetic content entirely, so only the faded suggestion is ever shown.

https://claude.ai/code/session_01R1yBerL1fSzgkJSCT5PUgf