### PR TITLE
Fix all-day SVG alignment, 15-min event clicks, and find panel focus

### DIFF
--- a/web/css/schedule.css
+++ b/web/css/schedule.css
@@ -373,6 +373,10 @@ body.schedule-dragging * {
 /* Hide resize handle inside the all-day section (those items are not resizable) */
 .schedule-allday-section .schedule-resize-handle { display: none; }
 
+/* For very short timed events (≤20px), shrink the resize handle so it doesn't
+   block clicks on the task checkbox or event title. */
+.schedule-item-short .schedule-resize-handle { height: 3px; }
+
 /* Prevent scroll-hijacking on draggable items (touch).
    The all-day items are also .schedule-item, so this rule covers them too. */
 .schedule-item { touch-action: pan-y; }

--- a/web/js/notes/global-search.js
+++ b/web/js/notes/global-search.js
@@ -19,8 +19,10 @@ let gsSelectedIndex  = -1;
 
 function openGlobalSearch() {
   globalSearchPanel.classList.remove('gs-hidden');
-  gsSearchInput.focus();
-  gsSearchInput.select();
+  setTimeout(() => {
+    gsSearchInput.focus();
+    gsSearchInput.select();
+  }, 0);
 }
 
 function closeGlobalSearch() {

--- a/web/js/schedule/schedule.js
+++ b/web/js/schedule/schedule.js
@@ -508,7 +508,7 @@ async function _doRenderSchedule(cachedNotes) {
     // Approximate pixel heights for SVG sizing
     // Each item: ALLDAY_ITEM_H (28px) + 5px bottom margin (no top margin) = 33px
     const ITEM_ROW_H = ALLDAY_ITEM_H + 5;
-    const expandedSvgH = Math.max(sorted.length * ITEM_ROW_H, 40);
+    const expandedSvgH = sorted.length * ITEM_ROW_H;
     const collapsedSvgH = Math.max(2 * ITEM_ROW_H, 40);
 
     const section = document.createElement('div');
@@ -623,6 +623,7 @@ async function _doRenderSchedule(cachedNotes) {
     const block = _makeScheduleBlock(item, classes);
     block.style.top    = top + 'px';
     block.style.height = height + 'px';
+    if (height <= 20) block.classList.add('schedule-item-short');
     // Store time bounds for conflict detection during drag
     block.dataset.startMins = startMin;
     block.dataset.endMins   = endMin;


### PR DESCRIPTION
- All-day section: remove 40px SVG height minimum so the toggle line
  spans exactly the height of the items, aligning with a single event
- 15-min events: add `schedule-item-short` class (height ≤ 20px) and
  shrink the resize handle to 3px so the task checkbox and title remain
  clickable
- Find & replace panel: defer focus/select to the next event loop tick
  so the search input reliably receives the cursor on open

https://claude.ai/code/session_012Teac1zeUAJWb6tSTswDYa