### PR TITLE
Fix empty blockquote lines not rendering when ">" has no text

### DIFF
--- a/web/js/editor/markdown-renderer.js
+++ b/web/js/editor/markdown-renderer.js
@@ -231,6 +231,14 @@ function preprocessMarkdown(text) {
     }).join('\n');
   }
 
+  // ── Empty blockquote lines: ensure bare ">" renders as an empty blockquote ──
+  // A ">" with nothing after it (or only spaces/tabs) produces no visible output
+  // from the parser. Appending a zero-width space (U+200B) gives the parser
+  // non-empty content while keeping the rendered line visually blank.
+  {
+    text = text.replace(/^( {0,3}>)[ \t]*$/gm, '$1 ​');
+  }
+
   // ── Indentation: convert leading tabs into padded HTML blocks ──
   {
     const lines = text.split('\n');


### PR DESCRIPTION
A line with only ">" (or ">" followed by spaces/tabs) was producing no
visible output because the markdown parser requires non-empty content to
emit a blockquote element. The fix appends a zero-width space (U+200B)
during preprocessing so the parser generates a properly-sized empty
blockquote while the rendered line remains visually blank.

https://claude.ai/code/session_01JKEgwuGnnbfzYF8h7cS1EP