### PR TITLE
Unify auto text insertions behind a deferred flush queue

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -234,6 +234,7 @@
   <!-- Note CRUD, file list, search, export/import -->
   <script defer src="js/notes/file-list.js"></script>
   <script defer src="js/notes/note-manager.js"></script>
+  <script defer src="js/editor/auto-edit-queue.js"></script>
   <script defer src="js/notes/export-import.js"></script>
   <script defer src="js/notes/global-search.js"></script>
 

--- a/web/js/core/app-init.js
+++ b/web/js/core/app-init.js
@@ -290,12 +290,26 @@ searchTasksBox.addEventListener('input', () => {
   _taskSearchDebounce = setTimeout(() => updateTodoList(), 200);
 });
 textarea.addEventListener('input', () => {
+  if (window.AutoEditQueue) window.AutoEditQueue.markDirty();
   clearTimeout(autoSaveTimer);
   if (currentFileName === null) {
     const firstNewlineIdx = textarea.value.indexOf('\n');
     if (firstNewlineIdx === -1 || textarea.selectionStart <= firstNewlineIdx) return;
   }
   autoSaveTimer = setTimeout(autoSaveNote, 1000);
+});
+
+// Cursor-line-change trigger for the auto-edit queue.  selectionchange fires
+// for every caret movement (Enter, Arrow keys, Home/End, mouse click) so we
+// filter by the textarea being focused and by line-index actually changing.
+document.addEventListener('selectionchange', () => {
+  if (document.activeElement !== textarea) return;
+  if (window.AutoEditQueue) window.AutoEditQueue.onSelectionChange();
+});
+textarea.addEventListener('focus', () => {
+  if (window.AutoEditQueue) {
+    window.AutoEditQueue.resetLineTracker(window.AutoEditQueue.currentLineIndex());
+  }
 });
 
 // ── Panel management ──────────────────────────────────────────────────────
@@ -500,6 +514,7 @@ async function handleAttachmentPaste(file) {
     insertAtCursor(md);
     updateStatus(`Attached ${safeFilename}.`, true);
     clearTimeout(autoSaveTimer);
+    if (window.AutoEditQueue) await window.AutoEditQueue.flush({ reason: 'attach' });
     await autoSaveNote();
   } catch (err) {
     console.error('Attachment error:', err);
@@ -542,8 +557,11 @@ document.addEventListener('keydown', e => {
   if ((e.ctrlKey || e.metaKey) && !e.shiftKey && (e.key === 's' || e.key === 'S')) {
     e.preventDefault();
     clearTimeout(autoSaveTimer);
+    const flushPromise = window.AutoEditQueue
+      ? window.AutoEditQueue.flush({ reason: 'manual-save' })
+      : Promise.resolve();
     try {
-      Promise.resolve(autoSaveNote()).then(
+      flushPromise.then(() => autoSaveNote()).then(
         () => updateStatus('Saved.', true),
         (err) => {
           console.error('[app-init] Ctrl+S save failed:', err);
@@ -1374,6 +1392,7 @@ function _setupPowerSyncHandlers() {
       if (autoSaveTimer !== null) {
         clearTimeout(autoSaveTimer);
         autoSaveTimer = null;
+        if (window.AutoEditQueue) await window.AutoEditQueue.flush({ reason: 'manual-save' });
         await autoSaveNote();
       }
       if (_forceSyncCallback) {
@@ -1412,6 +1431,7 @@ if (window.Capacitor?.isNativePlatform()) {
       if (autoSaveTimer !== null) {
         clearTimeout(autoSaveTimer);
         autoSaveTimer = null;
+        if (window.AutoEditQueue) await window.AutoEditQueue.flush({ reason: 'manual-save' });
         await autoSaveNote();
       }
       updateStatus('Syncing\u2026', true, true);

--- a/web/js/editor/auto-edit-queue.js
+++ b/web/js/editor/auto-edit-queue.js
@@ -1,0 +1,115 @@
+// ── Auto-edit queue ───────────────────────────────────────────────────────
+// Collects deferred rewrites of `textarea.value` and drains them only on
+// three triggers: cursor line change, view-mode toggle, note switch.
+//
+// Transforms are pure, idempotent `(text, ctx) -> text` rewrites; actions are
+// async side-effectful callbacks that may mutate storage.  Transforms run
+// first (in registration order), then actions.  Registrations reference
+// globals (_cleanupMarkdownTables, applyDailyNoteDateCodes, checkAttachmentRenames)
+// lazily via closures so script load order does not matter.
+
+(function () {
+  const transforms = [];
+  const actions = [];
+
+  let isDirty = false;
+  let _flushing = false;
+
+  function registerTransform(name, fn) { transforms.push({ name, fn }); }
+  function registerAction(name, fn)    { actions.push({ name, fn }); }
+
+  function markDirty() { isDirty = true; }
+
+  async function flush({ reason, generation } = {}) {
+    if (_flushing || !isDirty) return;
+    if (typeof textarea === 'undefined' || !textarea) return;
+    if (textarea.readOnly) { isDirty = false; return; }
+    if (!currentFileName) { isDirty = false; return; }
+
+    _flushing = true;
+    try {
+      const selStart = textarea.selectionStart;
+      const selEnd   = textarea.selectionEnd;
+      const before   = textarea.value;
+      const ctx = {
+        fileName: currentFileName,
+        prevSavedContent: _lastSavedContent,
+        reason,
+      };
+
+      let text = before;
+      for (const { fn } of transforms) {
+        try { text = fn(text, ctx); } catch (e) { console.error('[auto-edit-queue] transform failed:', e); }
+      }
+      if (text !== before) {
+        textarea.value = text;
+        const max = textarea.value.length;
+        textarea.selectionStart = Math.min(selStart, max);
+        textarea.selectionEnd   = Math.min(selEnd, max);
+        if (typeof refreshHighlight === 'function') refreshHighlight();
+      }
+
+      for (const { fn } of actions) {
+        if (generation !== undefined &&
+            typeof _loadNoteGeneration !== 'undefined' &&
+            generation !== _loadNoteGeneration) return;
+        try { await fn(ctx); } catch (e) { console.error('[auto-edit-queue] action failed:', e); }
+      }
+    } finally {
+      isDirty = false;
+      _flushing = false;
+    }
+  }
+
+  // Line-change tracker state (mutated by app-init listeners via resetLineTracker).
+  let _lastLineIndex = -1;
+  function resetLineTracker(idx = -1) { _lastLineIndex = idx; }
+  function currentLineIndex() {
+    if (typeof textarea === 'undefined' || !textarea) return 0;
+    const v = textarea.value;
+    const p = textarea.selectionStart;
+    let count = 0;
+    for (let i = 0; i < p; i++) if (v.charCodeAt(i) === 10) count++;
+    return count;
+  }
+  function onSelectionChange() {
+    const li = currentLineIndex();
+    if (li === _lastLineIndex) return;
+    _lastLineIndex = li;
+    flush({ reason: 'line-change' });
+  }
+
+  // ── Built-in registrations ──────────────────────────────────────────────
+  // Closures resolve globals at call time, so load-order of note-manager.js
+  // and table-features.js relative to this file does not matter.
+
+  registerTransform('daily-date-code', (text, ctx) => {
+    if (typeof applyDailyNoteDateCodes === 'function') {
+      return applyDailyNoteDateCodes(text, ctx.fileName);
+    }
+    return text;
+  });
+
+  registerTransform('table-cleanup', (text) => {
+    if (typeof _cleanupMarkdownTables === 'function') {
+      return _cleanupMarkdownTables(text);
+    }
+    return text;
+  });
+
+  registerAction('attachment-rename', async (ctx) => {
+    if (typeof checkAttachmentRenames === 'function') {
+      await checkAttachmentRenames(ctx.prevSavedContent, textarea.value, ctx.fileName);
+    }
+  });
+
+  window.AutoEditQueue = {
+    markDirty,
+    flush,
+    resetLineTracker,
+    currentLineIndex,
+    onSelectionChange,
+    registerTransform,
+    registerAction,
+  };
+})();

--- a/web/js/editor/markdown-renderer.js
+++ b/web/js/editor/markdown-renderer.js
@@ -3137,11 +3137,12 @@ async function toggleView() {
     }
     await applyPendingRename();
 
-    // Clean up table formatting before switching to preview.
-    const _cleanedText = _cleanupMarkdownTables(textarea.value);
-    if (_cleanedText !== textarea.value) {
-      textarea.value = _cleanedText;
-      await autoSaveNote();
+    // Drain queued auto-edits (table cleanup, daily date-code insertion,
+    // attachment renames) before rendering preview.  Persist any resulting
+    // textarea changes before rendering.
+    if (window.AutoEditQueue) {
+      await window.AutoEditQueue.flush({ reason: 'toggle-view' });
+      if (textarea.value !== _lastSavedContent) await autoSaveNote();
     }
 
     await renderPreview();

--- a/web/js/notes/note-manager.js
+++ b/web/js/notes/note-manager.js
@@ -370,11 +370,11 @@ async function checkAttachmentRenames(prevContent, newContent, noteName) {
 const _RE_DAILY_NOTE_NAME = /^(\d{6}) Daily Note$/;
 const _RE_BARE_TIMED = />\s*(\d{4})\s+(\d{4})(?:\s+@(\S+))?\s*$/;
 
-function _applyDailyDateCode(noteName) {
-  const dm = (noteName || '').match(_RE_DAILY_NOTE_NAME);
-  if (!dm) return false;
+function applyDailyNoteDateCodes(text, fileName) {
+  const dm = (fileName || '').match(_RE_DAILY_NOTE_NAME);
+  if (!dm) return text;
   const dateCode = dm[1];
-  const lines = textarea.value.split('\n');
+  const lines = text.split('\n');
   let changed = false;
   const newLines = lines.map(line => {
     if (_RE_TS_TIMED.test(line) || _RE_TS_MULTIDAY.test(line) || _RE_TS_ALLDAY.test(line)) return line;
@@ -387,13 +387,7 @@ function _applyDailyDateCode(noteName) {
     const tag = tm[3] ? ` @${tm[3]}` : '';
     return line.replace(_RE_BARE_TIMED, `> ${dateCode} ${tm[1]} ${tm[2]}${tag}`);
   });
-  if (changed) {
-    const sel = textarea.selectionStart, selEnd = textarea.selectionEnd;
-    textarea.value = newLines.join('\n');
-    textarea.selectionStart = sel;
-    textarea.selectionEnd = selEnd;
-  }
-  return changed;
+  return changed ? newLines.join('\n') : text;
 }
 
 // ── Auto-save ─────────────────────────────────────────────────────────────
@@ -411,17 +405,12 @@ async function autoSaveNote() {
   // Capture mutable globals at the start to avoid race conditions while
   // async operations yield to other event handlers.
   const capturedFileName = currentFileName;
-  let capturedContent = textarea.value;
-  const prevContent = _lastSavedContent;
+  const capturedContent = textarea.value;
 
   const name = getNoteTitle();
   if (!name) {
     updateStatus('File Not Saved. Please Add A Title Starting With "#".', false);
     return;
-  }
-
-  if (_applyDailyDateCode(name)) {
-    capturedContent = textarea.value;
   }
 
   const useSyncStorage = !!window.PowerSyncNoteStorage;
@@ -452,7 +441,6 @@ async function autoSaveNote() {
     if (scheduleContainer.classList.contains('active')) renderSchedule();
     await updateFileList();
     updateStatus(useSyncStorage ? 'Saved.' : 'File Saved Successfully.', true);
-    await checkAttachmentRenames(prevContent, capturedContent, currentFileName);
     return;
   }
 
@@ -485,7 +473,6 @@ async function autoSaveNote() {
     await updateTodoList();
     await updateFileList();
     updateStatus(useSyncStorage ? 'Saved.' : 'File Saved Successfully.', true);
-    await checkAttachmentRenames(prevContent, capturedContent, currentFileName);
     return;
   }
 
@@ -502,7 +489,6 @@ async function autoSaveNote() {
   if (scheduleContainer.classList.contains('active')) renderSchedule();
   await updateTodoList();
   updateStatus(useSyncStorage ? 'Saved.' : 'File Saved Successfully.', true);
-  await checkAttachmentRenames(prevContent, capturedContent, capturedFileName);
 }
 
 // ── Apply pending rename ───────────────────────────────────────────────────
@@ -581,6 +567,10 @@ async function loadNote(name, fromLink = false, prefetchedContent = null) {
     // If in preview mode, commit any active table sort into textarea.value so
     // the save-on-navigate block below picks it up and writes it to storage.
     if (isPreview) _saveAllTableSorts(previewDiv);
+    if (window.AutoEditQueue) {
+      await window.AutoEditQueue.flush({ reason: 'load-note', generation: gen });
+      if (gen !== _loadNoteGeneration) return;
+    }
     if (textarea.value !== _lastSavedContent) {
       try {
         await NoteStorage.setNote(currentFileName, textarea.value);
@@ -656,6 +646,7 @@ async function loadNote(name, fromLink = false, prefetchedContent = null) {
   _cacheNoteContent(name, content);
   currentFileName = name;
   refreshHighlight();
+  if (window.AutoEditQueue) window.AutoEditQueue.resetLineTracker(0);
   localStorage.setItem('current_file', name);
 
   const isReadOnlyNote = name === PROJECTS_NOTE || name === CALENDARS_NOTE || name === GRAPH_NOTE;
@@ -725,6 +716,7 @@ async function newNote() {
   if (currentFileName) {
     // Commit any active table sort into textarea.value before the save check.
     if (isPreview) _saveAllTableSorts(previewDiv);
+    if (window.AutoEditQueue) await window.AutoEditQueue.flush({ reason: 'new-note' });
     if (textarea.value !== _lastSavedContent) {
       try {
         await NoteStorage.setNote(currentFileName, textarea.value);
@@ -767,6 +759,7 @@ async function newNote() {
   _lastSavedContent = textarea.value;
   _lastRemoteContent = null;
   refreshHighlight();
+  if (window.AutoEditQueue) window.AutoEditQueue.resetLineTracker(0);
   const activeItem = fileList.querySelector('.active-file');
   if (activeItem) activeItem.classList.remove('active-file');
   updateStatus('', true);


### PR DESCRIPTION
Auto edits (daily-note date codes, markdown table cleanup, attachment link renaming) now queue until the user leaves the line, toggles the view mode, or switches notes, instead of firing mid-typing from the 1s autosave debounce.