### PR TITLE
Fix table row suggestion rendering as both ghost and plain text

### DIFF
--- a/web/js/editor/table-features.js
+++ b/web/js/editor/table-features.js
@@ -519,10 +519,10 @@ function _fallbackCopy(text, glowTarget) {
   // Remove the ghost span from the pre.  Synchronous — safe to call in input handler.
   function _trHide() {
     if (typeof _highlightPre !== 'undefined' && _highlightPre) {
-      _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => {
-        while (s.firstChild) s.parentNode.insertBefore(s.firstChild, s);
-        s.parentNode.removeChild(s);
-      });
+      // Remove the span AND its text content — unwrapping (hoisting children
+      // out) leaves the ghost text as plain text in the pre, which then shows
+      // as a duplicate once the next ghost is injected at the same offset.
+      _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => s.remove());
     }
     _ghostInsertPos = null;
     _ghostText      = '';
@@ -534,11 +534,8 @@ function _fallbackCopy(text, glowTarget) {
   // has already updated the pre with the current textarea content.
   function _applyGhostToPre() {
     if (_ghostInsertPos === null || typeof _highlightPre === 'undefined' || !_highlightPre) return;
-    // Remove any stale ghost span.
-    _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => {
-      while (s.firstChild) s.parentNode.insertBefore(s.firstChild, s);
-      s.parentNode.removeChild(s);
-    });
+    // Remove any stale ghost span (including its text content — see _trHide).
+    _highlightPre.querySelectorAll('.table-ghost-text').forEach(s => s.remove());
     // Walk text nodes to find the character offset.
     const walker = document.createTreeWalker(_highlightPre, NodeFilter.SHOW_TEXT);
     let remaining = _ghostInsertPos;


### PR DESCRIPTION
_trHide and _applyGhostToPre were unwrapping the ghost span (hoisting its children out, then removing the empty span), which left the ghost suggestion as plain text in the highlight pre. When _applyGhostToPre ran a second time within the same input cycle — which happens whenever _updateHighlight injects a fresh ghost at t=10ms before the 50ms setTimeout fires — the "stale ghost" cleanup unwrapped the freshly injected span into plain text, then re-injected a new ghost span at the same offset. Net effect: the suggestion showed twice, once faded and once at full opacity, immediately after accepting a row with Enter.

Replace the unwrap-then-remove pattern with s.remove() so the span and its text content go away together.

https://claude.ai/code/session_01PJBvKQkbKKYkzVYCsyBvtY